### PR TITLE
refine implementation plan and enhance registry with type hints; update indexer for better type handling

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -59,23 +59,22 @@ CodeWeaver has evolved beyond its original architectural vision into a sophistic
 ### ❌ **Critical Gaps - What Needs Completion**
 
 **Core Integration**:
-- ✅ CLI implementation (comprehensive with server, search, config commands)
-- Provider registry system (`_registry.py`)
-- FastMCP middleware and application state management
+- Provider registry system (`_registry.py`) -- mostly done but needs to be connected and service registry remains incomplete
 - Vector store implementations (Qdrant incomplete, memory store basic)
-- Integration of vendored search system into `find_code` tool interface
+- Integration of vendored search system into `find_code` tool interface (in `src/codeweaver/services`: `_wrap_filters.py`, `_matched_models.py`, `filter.py`)
 
 **Pipeline Components**:
 - Background indexing with file watching
 - Semantic embedding integration
 - pydantic-graph orchestration
-- Query intent analysis implementation
+- Query intent analysis implementation with heuristic/nlp approach and agent-driven approach using mcp sampling
+- Evaluation system (pydantic-eval)
 
 **Infrastructure**:
 - Comprehensive testing framework
 - Error handling and graceful degradation
 - Performance optimization and caching
-- Authentication/authorization middleware
+- Authentication/authorization middleware (very little needs to be done here, but components need to be properly scoped to support it)
 
 ---
 

--- a/src/codeweaver/_registry.py
+++ b/src/codeweaver/_registry.py
@@ -569,9 +569,9 @@ class ModelRegistry(BasedModel):
                 profile(name) if callable(profile) else profile
                 for glob, profile in rules
                 if glob == name or fnmatch(name, glob)
-            ),
+            ),  # type: ignore
             None,
-        )
+        )  # pyright: ignore[reportUnknownVariableType]
 
     def _register_builtin_agentic_profiles(self) -> None:
         """Register built-in agentic profiles."""
@@ -582,9 +582,9 @@ class ModelRegistry(BasedModel):
             with contextlib.suppress(ValueError, AttributeError, ImportError):
                 profile: Model = infer_model(model_name)
                 provider = Provider.from_string(
-                    profile._profile.split(":")[1]
-                    if len(profile._profile.split(":")) > 1
-                    else profile._profile
+                    profile._profile.split(":")[1]  # type: ignore
+                    if len(profile._profile.split(":")) > 1  # type: ignore
+                    else profile._profile  # type: ignore
                 )
                 if not provider:
                     console.print(
@@ -772,7 +772,8 @@ class ProviderRegistry(BasedModel):
                     module = __import__(module_path, fromlist=["*"])
                     self._register_provider_by_kind(provider_kind, provider, module, module_path)
         self._register_azure_exception_providers(Provider.AZURE)
-        # * NOTE: Embedding providers using OpenAIEmbeddingBase still need a class created to get instantiated. But no point building it until it's needed.
+        # * NOTE: Embedding providers using OpenAIEmbeddingBase still need a class *created* before getting instantiated. But no point building it until it's needed.
+        # * OpenAIEmbeddingBase is a class factory
 
     def _register_provider_by_kind(
         self, provider_kind: ProviderKind, provider: Provider, module: Any, module_path: str

--- a/src/codeweaver/services/indexer.py
+++ b/src/codeweaver/services/indexer.py
@@ -11,6 +11,7 @@
 # TODO: implement file watcher
 # TODO: register with providers registry
 
+from collections.abc import Sequence
 from pathlib import Path
 
 import rignore
@@ -21,7 +22,7 @@ type WatchfilesAwatch = watchfiles.awatch | None
 
 
 class IgnoreFilter[Walker](watchfiles.DefaultFilter):
-    pass
+    ignore_dirs: Sequence[str]
 
 
 class FileWatcher[WatchfilesAwatch]:


### PR DESCRIPTION
## Summary by Sourcery

Refine the project’s implementation plan docs, add type hint accommodations in the provider registry, and extend the indexer’s filter to accept ignore directories

Enhancements:
- Suppress type checker errors in resolve_agentic_profile and _register_builtin_agentic_profiles by adding type ignore comments
- Clarify OpenAIEmbeddingBase as a class factory in the provider registry notes
- Extend IgnoreFilter in the file watcher to include an ignore_dirs attribute

Documentation:
- Update IMPLEMENTATION_PLAN.md to refine the status and requirements for the provider registry, search integration, query intent analysis, evaluation system, and authentication middleware