### PR TITLE
fix: implement proper symbol identification using tree-sitter field e…

### DIFF
--- a/src/codeweaver/semantic/ast_grep.py
+++ b/src/codeweaver/semantic/ast_grep.py
@@ -441,8 +441,22 @@ class AstThing[SgNode: (AstGrepNode)](BasedModel):
     @computed_field
     @property
     def symbol(self) -> str:
-        """Get a symbolic representation of the node."""
-        # Return the node's text as a simple symbol representation
+        """Get a symbolic representation of the node.
+
+        For structured nodes (functions, classes, variables), extracts the identifier
+        from the 'name' field. For simple tokens, returns the node's text.
+
+        This follows the standard tree-sitter pattern used by LSP implementations
+        and code intelligence tools, where semantic fields like 'name' contain
+        the identifier for structured constructs.
+        """
+        # Try to extract symbol from the 'name' field for structured nodes
+        # This is the standard approach used across tree-sitter grammars
+        with contextlib.suppress(Exception):
+            if name_node := self._node.field("name"):
+                return name_node.text()
+
+        # Fallback to the node's text for tokens and unnamed structures
         return self.text
 
     @computed_field


### PR DESCRIPTION
…xtraction

The previous implementation of the `symbol` property simply returned `self.text`, which didn't correctly identify symbols from tree-sitter AST nodes.

This fix implements the standard tree-sitter pattern for symbol identification:
1. Extract the identifier from the 'name' field for structured nodes (functions, classes, variables, etc.)
2. Fallback to the node's text for tokens and unnamed structures

This approach:
- Follows the pattern already used in semantic.py:646
- Aligns with standard LSP implementations and code intelligence tools
- Uses the semantic fields defined in tree-sitter grammars across languages

Fixes #111

## Summary by Sourcery

Bug Fixes:
- Correct symbol resolution for tree-sitter AST nodes by using the identifier from the 'name' field when present instead of always returning the full node text.