### PR TITLE
chore: Add plans for server separation of services refactor to enable…

### DIFF
--- a/src/codeweaver/providers/vector_stores/qdrant_base.py
+++ b/src/codeweaver/providers/vector_stores/qdrant_base.py
@@ -607,7 +607,7 @@ class QdrantBaseProvider(VectorStoreProvider[AsyncQdrantClient], ABC):
                 if isinstance(sparse_emb, CodeWeaverSparseEmbedding):
                     self._prepare_sparse_vector_data(sparse_emb, SparseVector, vectors)
             elif isinstance(sparse_info, CodeWeaverSparseEmbedding):
-                self._extracted_from__prepare_vectors_34(sparse_info, SparseVector, vectors)
+                self._prepare_sparse_vector_data(sparse_info, SparseVector, vectors)
         return vectors
 
     def _prepare_sparse_vector_data(


### PR DESCRIPTION
## Description

Fixed bug in `qdrant_base.py:610` where a non-existent method `_extracted_from__prepare_vectors_34()` was being called instead of the correct method `_prepare_sparse_vector_data()`.

This was a refactoring artifact (likely from an automated tool like Sourcery) that caused sparse-only vector searches to fail with 0 results.

## Changes

- Fixed method call in `src/codeweaver/providers/vector_stores/qdrant_base.py:610`
- Changed from: `self._extracted_from__prepare_vectors_34(...)`
- Changed to: `self._prepare_sparse_vector_data(...)`

## Investigation

Also investigated the Claude action premature termination issue. See issue comments for detailed findings and recommendations.

## Testing

This should fix the following xfail tests:
- `tests/integration/test_hybrid_storage.py::test_store_hybrid_embeddings`
- `tests/integration/test_partial_embeddings.py::test_partial_embeddings`

Fixes #115

---
Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Bug Fixes:
- Correct sparse-only vector handling in Qdrant base store by calling the proper sparse vector preparation method instead of a non-existent helper.