### PR TITLE
fix(tests): resolve configuration validation flow test issues

### DIFF
--- a/src/codeweaver/core/config/core_settings.py
+++ b/src/codeweaver/core/config/core_settings.py
@@ -460,7 +460,8 @@ class CodeWeaverCoreSettings(BaseCodeWeaverSettings):
 
     def _set_unset_fields(self, **kwargs: Any) -> None:
         """Update the set of unset fields based on provided kwargs."""
-        self._unset_fields = self._unset_fields or set()
+        if not hasattr(self, "_unset_fields") or self._unset_fields is None:
+            self._unset_fields = set()
         self._unset_fields |= {
             key for key in kwargs if kwargs[key] is UNSET and key in type(self).model_fields
         }

--- a/src/codeweaver/engine/config/root_settings.py
+++ b/src/codeweaver/engine/config/root_settings.py
@@ -94,7 +94,7 @@ class CodeWeaverEngineSettings(CodeWeaverProviderSettings):
         data["failover"] = (
             failover
             if failover is not UNSET and failover is not None
-            else FailoverSettings.model_construct(**DefaultFailoverSettings)
+            else FailoverSettings.model_construct(**DefaultFailoverSettings())
         )
         super().__init__(**data)
 

--- a/src/codeweaver/providers/config/root_settings.py
+++ b/src/codeweaver/providers/config/root_settings.py
@@ -103,18 +103,11 @@ class CodeWeaverProviderSettings(CodeWeaverCoreSettings):
             else:
                 data["provider"] = provider
         else:
+            actual_profile = profile if profile is not UNSET and profile is not None else (
+                ProviderProfile.TESTING if is_test_environment() else ProviderProfile.RECOMMENDED
+            )
             data["provider"] = ProviderSettings.model_construct(
-                **cast(
-                    ProviderProfile,
-                    (
-                        profile
-                        or (
-                            ProviderProfile.TESTING
-                            if is_test_environment()
-                            else ProviderProfile.RECOMMENDED
-                        )
-                    ),
-                ).as_provider_settings()
+                **cast(ProviderProfile, actual_profile).as_provider_settings()
             )
         super().__init__(**data)
 

--- a/src/codeweaver/server/config/settings.py
+++ b/src/codeweaver/server/config/settings.py
@@ -329,7 +329,7 @@ class CodeWeaverSettings(CodeWeaverEngineSettings):
         data["stdio_server"] = (
             stdio_server
             if stdio_server is not UNSET and stdio_server is not None
-            else FastMcpStdioServerSettings.model_construct(**BaseFastMcpServerSettings)
+            else FastMcpStdioServerSettings.model_construct(**DefaultFastMcpServerSettings)
         )
         data["middleware"] = (
             middleware

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ from uuid import UUID
 
 import pytest
 
-from pydantic.types import UUID7
+from pydantic import UUID7
 from qdrant_client import AsyncQdrantClient
 
 from codeweaver.core import (

--- a/tests/integration/test_config_validation_flow.py
+++ b/tests/integration/test_config_validation_flow.py
@@ -113,8 +113,7 @@ def mock_checkpoint_manager(test_checkpoint_data: dict) -> Mock:
     manager.load = AsyncMock(return_value=checkpoint)
     manager.save = AsyncMock()
     manager.delete = AsyncMock()
-    # Some tests may call `load_checkpoint()` instead of `load()`;
-    # make it an alias so both return the same checkpoint object.
+    # Alias provided for backwards compatibility if needed.
     if hasattr(manager, "load_checkpoint"):
         manager.load_checkpoint = manager.load
     if hasattr(manager, "validate_checkpoint_compatibility"):
@@ -336,7 +335,7 @@ class TestConfigChangeClassification:
         new_config.datatype = "float32"
 
         # Get checkpoint metadata
-        checkpoint = await mock_checkpoint_manager.load_checkpoint()
+        checkpoint = await mock_checkpoint_manager.load()
 
         # Create fingerprint from checkpoint metadata
         from codeweaver.engine.managers.checkpoint_manager import CheckpointSettingsFingerprint
@@ -382,7 +381,7 @@ class TestConfigChangeClassification:
         new_config.dimension = 1024  # Reduced from 2048
         new_config.datatype = "float32"
 
-        checkpoint = await mock_checkpoint_manager.load_checkpoint()
+        checkpoint = await mock_checkpoint_manager.load()
 
         # Create fingerprint from checkpoint metadata
         from codeweaver.engine.managers.checkpoint_manager import CheckpointSettingsFingerprint
@@ -430,7 +429,7 @@ class TestConfigChangeClassification:
         new_config.dimension = 2048
         new_config.datatype = "float32"
 
-        checkpoint = await mock_checkpoint_manager.load_checkpoint()
+        checkpoint = await mock_checkpoint_manager.load()
 
         # Create fingerprint from checkpoint metadata
         from codeweaver.engine.managers.checkpoint_manager import CheckpointSettingsFingerprint
@@ -556,7 +555,7 @@ class TestEmpiricalDataUsage:
         new_config.dimension = 512
         new_config.datatype = "float32"
 
-        checkpoint = await mock_checkpoint_manager.load_checkpoint()
+        checkpoint = await mock_checkpoint_manager.load()
 
         # Create fingerprint
         from codeweaver.engine.managers.checkpoint_manager import CheckpointSettingsFingerprint
@@ -605,7 +604,7 @@ class TestEmpiricalDataUsage:
         new_config.dimension = 768  # Uncommon dimension
         new_config.datatype = "float32"
 
-        checkpoint = await mock_checkpoint_manager.load_checkpoint()
+        checkpoint = await mock_checkpoint_manager.load()
 
         # Create fingerprint
         from codeweaver.engine.managers.checkpoint_manager import CheckpointSettingsFingerprint
@@ -656,7 +655,7 @@ class TestEdgeCasesIntegration:
         from codeweaver.engine.services.config_analyzer import ConfigChangeAnalyzer
 
         # Update checkpoint with large vector count
-        checkpoint = await mock_checkpoint_manager.load_checkpoint()
+        checkpoint = await mock_checkpoint_manager.load()
         checkpoint.total_vectors = 10_000_000
 
         analyzer = ConfigChangeAnalyzer(
@@ -703,7 +702,7 @@ class TestEdgeCasesIntegration:
         test_settings: Mock,
     ) -> None:
         """Test handling of collection with zero vectors."""
-        checkpoint = await mock_checkpoint_manager.load_checkpoint()
+        checkpoint = await mock_checkpoint_manager.load()
         checkpoint.total_vectors = 0
 
         from codeweaver.engine.services.config_analyzer import ConfigChangeAnalyzer
@@ -778,7 +777,7 @@ class TestRecommendationsQuality:
         new_config.dimension = 2048
         new_config.datatype = "float32"
 
-        checkpoint = await mock_checkpoint_manager.load_checkpoint()
+        checkpoint = await mock_checkpoint_manager.load()
 
         # Create fingerprint
         from codeweaver.engine.managers.checkpoint_manager import CheckpointSettingsFingerprint
@@ -827,7 +826,7 @@ class TestRecommendationsQuality:
         new_config.dimension = 512  # Reduction
         new_config.datatype = "float32"
 
-        checkpoint = await mock_checkpoint_manager.load_checkpoint()
+        checkpoint = await mock_checkpoint_manager.load()
 
         # Create fingerprint
         from codeweaver.engine.managers.checkpoint_manager import CheckpointSettingsFingerprint
@@ -888,7 +887,7 @@ class TestTimeAndCostEstimates:
         new_config.dimension = 1024
         new_config.datatype = "float32"
 
-        await mock_checkpoint_manager.load_checkpoint()
+        await mock_checkpoint_manager.load()
 
         # Create fingerprint
         from codeweaver.engine.managers.checkpoint_manager import CheckpointSettingsFingerprint
@@ -940,7 +939,7 @@ class TestTimeAndCostEstimates:
         new_config.dimension = 2048
         new_config.datatype = "float32"
 
-        checkpoint = await mock_checkpoint_manager.load_checkpoint()
+        checkpoint = await mock_checkpoint_manager.load()
 
         # Create fingerprint
         from codeweaver.engine.managers.checkpoint_manager import CheckpointSettingsFingerprint


### PR DESCRIPTION
This PR addresses failing integration tests by resolving several issues related to Pydantic instantiation and mock configuration:

1. Fixed dynamic settings instantiation in `root_settings.py` and `settings.py` so proper dictionary overrides are provided (`DefaultFailoverSettings()` and `DefaultFastMcpServerSettings`).
2. Addressed an `AttributeError` encountered when setting fields dynamically via `_set_unset_fields` by adding explicit `hasattr` fallbacks for `_unset_fields`.
3. Added strict evaluations against `UNSET` and `None` to ensure fallback profiles are cleanly resolved.
4. Cleaned up outdated `load_checkpoint` test mocks in `test_config_validation_flow.py` to correctly map to the `load` method.

These fixes drop the integration test failures in `test_config_validation_flow.py` from 11 down to 4.

---
*PR created automatically by Jules for task [11230534839343970770](https://jules.google.com/task/11230534839343970770) started by @bashandbone*

## Summary by Sourcery

Fix configuration defaults and checkpoint mocks to resolve failing configuration validation flow tests.

Bug Fixes:
- Correct provider profile resolution to avoid treating UNSET or None as valid profiles when constructing ProviderSettings.
- Ensure unset field tracking initializes safely even when _unset_fields is missing or None.
- Fix failover settings construction to use the DefaultFailoverSettings factory instead of the class itself.
- Fix stdio server settings construction to use DefaultFastMcpServerSettings for default configuration.
- Align integration tests with the checkpoint manager API by calling load instead of load_checkpoint and updating the mock alias behavior.

Tests:
- Update configuration validation flow integration tests to use the current checkpoint manager interface and maintain backward-compatible mocking behavior.