### PR TITLE
🧹 Remove deprecated and unused combined_lifespan alias

### DIFF
--- a/src/codeweaver/server/lifespan.py
+++ b/src/codeweaver/server/lifespan.py
@@ -199,8 +199,4 @@ async def http_lifespan(
         yield background_state
 
 
-# Backward compatibility alias (deprecated)
-combined_lifespan = http_lifespan
-
-
 __all__ = ("background_services_lifespan", "http_lifespan")


### PR DESCRIPTION
🎯 **What:** Removed the deprecated `combined_lifespan` backward compatibility alias and its comment in `src/codeweaver/server/lifespan.py`.
💡 **Why:** This assignment (`combined_lifespan = http_lifespan`) is no longer used. Removing it eliminates dead code, improves code health, and reduces potential confusion regarding the module's API.
✅ **Verification:** Verified by checking references in the codebase (it was completely unused) and running `uv run pytest tests/unit/server/ --no-cov`. All 32 server-related tests passed, ensuring no functionality is broken.
✨ **Result:** A cleaner `lifespan.py` without deprecated aliases, leading to better maintainability and readability.

---
*PR created automatically by Jules for task [11695823115261314285](https://jules.google.com/task/11695823115261314285) started by @bashandbone*

## Summary by Sourcery

Enhancements:
- Clean up the server lifespan module by removing an obsolete backward compatibility alias.