### PR TITLE
test: update CircuitBreakerState to use .variable

### DIFF
--- a/tests/integration/server/test_error_recovery.py
+++ b/tests/integration/server/test_error_recovery.py
@@ -37,7 +37,7 @@ def create_failing_provider_mock() -> MagicMock:
     mock_provider.name = Provider.OPENAI  # Set name property
     mock_provider.embed_query = AsyncMock(side_effect=ConnectionError("Simulated API failure"))
     mock_provider.embed_documents = AsyncMock(side_effect=ConnectionError("Simulated API failure"))
-    mock_provider.circuit_breaker_state = CircuitBreakerState.CLOSED.value
+    mock_provider.circuit_breaker_state = CircuitBreakerState.CLOSED.variable
     mock_provider._circuit_state = CircuitBreakerState.CLOSED
     mock_provider._failure_count = 0
     mock_provider._last_failure_time = None
@@ -67,7 +67,7 @@ def create_half_open_provider_mock() -> MagicMock:
     mock_provider = MagicMock(spec=EmbeddingProvider)
     mock_provider.embed_query = AsyncMock(side_effect=mock_embed_query)
     mock_provider.embed_documents = AsyncMock(side_effect=mock_embed_documents)
-    mock_provider.circuit_breaker_state = CircuitBreakerState.CLOSED.value
+    mock_provider.circuit_breaker_state = CircuitBreakerState.CLOSED.variable
     mock_provider._circuit_state = CircuitBreakerState.CLOSED
     mock_provider._failure_count = 0
     mock_provider._last_failure_time = None
@@ -100,7 +100,7 @@ def create_flaky_provider_mock() -> MagicMock:
     mock_provider = MagicMock(spec=EmbeddingProvider)
     mock_provider.embed_query = AsyncMock(side_effect=mock_embed_query)
     mock_provider.embed_documents = AsyncMock(side_effect=mock_embed_documents)
-    mock_provider.circuit_breaker_state = CircuitBreakerState.CLOSED.value
+    mock_provider.circuit_breaker_state = CircuitBreakerState.CLOSED.variable
     mock_provider._circuit_state = CircuitBreakerState.CLOSED
     mock_provider._failure_count = 0
     mock_provider._last_failure_time = None
@@ -261,7 +261,7 @@ async def test_circuit_breaker_opens():
             provider._last_failure_time = time.time()
             if provider._failure_count >= 3:
                 provider._circuit_state = CircuitBreakerState.OPEN
-                provider.circuit_breaker_state = CircuitBreakerState.OPEN.value
+                provider.circuit_breaker_state = CircuitBreakerState.OPEN.variable
 
         assert provider._failure_count == 3
         assert provider._circuit_state == CircuitBreakerState.OPEN
@@ -297,7 +297,7 @@ async def test_circuit_breaker_half_open():
                 provider._last_failure_time = time.time()
                 if provider._failure_count >= 3:
                     provider._circuit_state = CircuitBreakerState.OPEN
-                    provider.circuit_breaker_state = CircuitBreakerState.OPEN.value
+                    provider.circuit_breaker_state = CircuitBreakerState.OPEN.variable
 
         assert provider._circuit_state == CircuitBreakerState.OPEN
 
@@ -306,7 +306,7 @@ async def test_circuit_breaker_half_open():
 
         # Transition to half-open
         provider._circuit_state = CircuitBreakerState.HALF_OPEN
-        provider.circuit_breaker_state = CircuitBreakerState.HALF_OPEN.value
+        provider.circuit_breaker_state = CircuitBreakerState.HALF_OPEN.variable
 
         # Next request should succeed and close circuit
         result = await provider.embed_query("test_half_open")
@@ -314,7 +314,7 @@ async def test_circuit_breaker_half_open():
 
         # Success should close circuit
         provider._circuit_state = CircuitBreakerState.CLOSED
-        provider.circuit_breaker_state = CircuitBreakerState.CLOSED.value
+        provider.circuit_breaker_state = CircuitBreakerState.CLOSED.variable
         provider._failure_count = 0
         provider._last_failure_time = None
 

--- a/tests/integration/server/test_health_monitoring.py
+++ b/tests/integration/server/test_health_monitoring.py
@@ -34,6 +34,7 @@ import pytest
 
 from codeweaver.core import FailoverStats, Identifier, SessionStatistics
 from codeweaver.engine import IndexingService, IndexingStats
+from codeweaver.providers import CircuitBreakerState
 from codeweaver.server import (
     HealthResponse,
     HealthService,
@@ -108,7 +109,7 @@ def mock_providers(mocker) -> dict:
     embedding_instance.model_name = "voyage-code-3"
     embedding_instance.__class__.__name__ = "VoyageEmbeddingProvider"
     embedding_instance.circuit_breaker_state = mocker.MagicMock()
-    embedding_instance.circuit_breaker_state.variable = "closed"
+    embedding_instance.circuit_breaker_state.variable = CircuitBreakerState.CLOSED.variable
 
     # Mock sparse embedding provider
     sparse_instance = mocker.MagicMock()
@@ -119,7 +120,7 @@ def mock_providers(mocker) -> dict:
     reranking_instance.model_name = "voyage-rerank-2.5"
     reranking_instance.__class__.__name__ = "VoyageRerankingProvider"
     reranking_instance.circuit_breaker_state = mocker.MagicMock()
-    reranking_instance.circuit_breaker_state.variable = "closed"
+    reranking_instance.circuit_breaker_state.variable = CircuitBreakerState.CLOSED.variable
 
     return {
         "embedding": (embedding_instance,),
@@ -325,8 +326,7 @@ async def test_health_status_degraded(health_service: HealthService, mocker):
     """
     # Mock embedding provider as down (circuit breaker open)
     embedding_instance = health_service._providers["embedding"][0]
-    # FIX: Use .variable instead of .value to match BaseEnum interface
-    embedding_instance.circuit_breaker_state.variable = "open"
+    embedding_instance.circuit_breaker_state.variable = CircuitBreakerState.OPEN.variable
 
     response = await health_service.get_health_response()
 
@@ -429,16 +429,14 @@ async def test_health_circuit_breaker_exposure(health_service: HealthService, mo
 
     # Test half_open state
     embedding_instance = health_service._providers["embedding"][0]
-    # FIX: Use .variable instead of .value to match BaseEnum interface
-    embedding_instance.circuit_breaker_state.variable = "half_open"
+    embedding_instance.circuit_breaker_state.variable = CircuitBreakerState.HALF_OPEN.variable
 
     response2 = await health_service.get_health_response()
     assert response2.services.embedding_provider.circuit_breaker_state == "half_open"
     assert response2.services.embedding_provider.status == "up"
 
     # Test open state (service down)
-    # FIX: Use .variable instead of .value to match BaseEnum interface
-    embedding_instance.circuit_breaker_state.variable = "open"
+    embedding_instance.circuit_breaker_state.variable = CircuitBreakerState.OPEN.variable
 
     response3 = await health_service.get_health_response()
     assert response3.services.embedding_provider.circuit_breaker_state == "open"


### PR DESCRIPTION
Fixes `# FIX:` comments in `tests/integration/server/test_health_monitoring.py` by replacing `.value` or plain string literals assigned to `circuit_breaker_state.variable` with the proper `CircuitBreakerState.<STATE>.variable` enum properties.

Also updates `tests/integration/server/test_error_recovery.py` to use `.variable` instead of `.value` for consistency with the `BaseEnum` interface.

---
*PR created automatically by Jules for task [6088664127128084659](https://jules.google.com/task/6088664127128084659) started by @bashandbone*

## Summary by Sourcery

Align circuit breaker state handling in tests with the CircuitBreakerState enum’s variable-based interface.

Bug Fixes:
- Correct circuit breaker state assignments in health monitoring tests to use the enum’s variable property instead of raw strings.

Enhancements:
- Update error recovery and health monitoring tests to use CircuitBreakerState.<STATE>.variable for consistency with the BaseEnum interface.

Tests:
- Adjust integration tests for error recovery and health monitoring to reference CircuitBreakerState variables rather than enum values or string literals.