### PR TITLE
🧪 test(core): cover conditional branches in DiscoveredFile from_path

### DIFF
--- a/tests/unit/core/test_discovery.py
+++ b/tests/unit/core/test_discovery.py
@@ -11,7 +11,9 @@ from unittest.mock import patch
 import pytest
 
 from codeweaver.core.discovery import DiscoveredFile
-from codeweaver.core.metadata import ExtCategory
+from codeweaver.core.metadata import ChunkKind, ExtCategory
+from codeweaver.core.language import SemanticSearchLanguage
+from codeweaver.core.utils import get_blake_hash
 
 
 pytestmark = [pytest.mark.unit]
@@ -86,3 +88,153 @@ def test_absolute_path_when_project_path_is_none_filenotfound(mock_get_project_p
 
     # It should catch FileNotFoundError and return self.path
     assert result == rel_path
+
+
+@patch('codeweaver.core.discovery.ExtCategory.from_file')
+def test_from_path_ext_category_none(mock_from_file, tmp_path: Path) -> None:
+    """Test from_path returns None when ExtCategory.from_file returns None."""
+    mock_from_file.return_value = None
+    test_file = tmp_path / "test.unknown"
+    test_file.write_text("content")
+
+    result = DiscoveredFile.from_path(test_file, project_path=tmp_path)
+    assert result is None
+
+
+@patch('codeweaver.core.discovery.get_blake_hash')
+@patch('codeweaver.core.discovery.get_git_branch')
+@patch('codeweaver.core.discovery.ExtCategory.from_file')
+def test_from_path_directory_path(mock_from_file, mock_get_git_branch, mock_get_blake_hash, tmp_path: Path) -> None:
+    """Test from_path correctly handles a directory path for git branch check."""
+    real_ext = ExtCategory(language=SemanticSearchLanguage.PYTHON, kind=ChunkKind.CODE)
+    mock_from_file.return_value = real_ext
+    mock_get_git_branch.return_value = "feature-branch"
+    mock_get_blake_hash.return_value = "fake_hash"
+
+    test_dir = tmp_path / "somedir"
+    test_dir.mkdir()
+
+    # from_path requires the path to be read, which fails for a directory in read_bytes
+    # We mock read_bytes to avoid IsADirectoryError and focus on the branch logic
+    with patch.object(Path, 'read_bytes', return_value=b"content"):
+        result = DiscoveredFile.from_path(test_dir, project_path=tmp_path)
+
+    mock_get_git_branch.assert_called_once_with(test_dir)
+    assert result is not None
+    assert result.git_branch == "feature-branch"
+
+
+@patch('codeweaver.core.discovery.get_git_branch')
+@patch('codeweaver.core.discovery.ExtCategory.from_file')
+def test_from_path_file_path(mock_from_file, mock_get_git_branch, tmp_path: Path) -> None:
+    """Test from_path correctly handles a file path for git branch check."""
+    real_ext = ExtCategory(language=SemanticSearchLanguage.PYTHON, kind=ChunkKind.CODE)
+    mock_from_file.return_value = real_ext
+    mock_get_git_branch.return_value = "feature-branch"
+
+    test_file = tmp_path / "test.py"
+    test_file.write_text("content")
+
+    result = DiscoveredFile.from_path(test_file, project_path=tmp_path)
+
+    mock_get_git_branch.assert_called_once_with(tmp_path)
+    assert result is not None
+    assert result.git_branch == "feature-branch"
+
+
+@patch('codeweaver.core.discovery.get_git_branch')
+@patch('codeweaver.core.discovery.ExtCategory.from_file')
+def test_from_path_git_branch_fallback(mock_from_file, mock_get_git_branch, tmp_path: Path) -> None:
+    """Test from_path falls back to 'main' when get_git_branch returns None."""
+    real_ext = ExtCategory(language=SemanticSearchLanguage.PYTHON, kind=ChunkKind.CODE)
+    mock_from_file.return_value = real_ext
+    mock_get_git_branch.return_value = None
+
+    test_file = tmp_path / "test.py"
+    test_file.write_text("content")
+
+    result = DiscoveredFile.from_path(test_file, project_path=tmp_path)
+
+    assert result is not None
+    assert result.git_branch == "main"
+
+
+@patch('codeweaver.core.discovery.logger.warning')
+@patch('codeweaver.core.discovery.ExtCategory.from_file')
+def test_from_path_mismatched_file_hash(mock_from_file, mock_warning, tmp_path: Path) -> None:
+    """Test from_path issues a warning when provided file_hash does not match computed hash."""
+    real_ext = ExtCategory(language=SemanticSearchLanguage.PYTHON, kind=ChunkKind.CODE)
+    mock_from_file.return_value = real_ext
+
+    test_file = tmp_path / "test.py"
+    test_file.write_text("actual content")
+    computed_hash = get_blake_hash(b"actual content")
+    mismatched_hash = get_blake_hash(b"different content")
+
+    result = DiscoveredFile.from_path(test_file, file_hash=mismatched_hash, project_path=tmp_path)
+
+    assert result is not None
+    assert result.file_hash == computed_hash
+    mock_warning.assert_called_once_with(
+        "Provided file_hash does not match computed hash for %s. Using computed hash.",
+        test_file,
+    )
+
+
+@patch('codeweaver.core.discovery.logger.warning')
+@patch('codeweaver.core.discovery.ExtCategory.from_file')
+def test_from_path_matching_file_hash(mock_from_file, mock_warning, tmp_path: Path) -> None:
+    """Test from_path does not issue a warning when provided file_hash matches computed hash."""
+    real_ext = ExtCategory(language=SemanticSearchLanguage.PYTHON, kind=ChunkKind.CODE)
+    mock_from_file.return_value = real_ext
+
+    test_file = tmp_path / "test.py"
+    test_file.write_text("actual content")
+    matching_hash = get_blake_hash(b"actual content")
+
+    result = DiscoveredFile.from_path(test_file, file_hash=matching_hash, project_path=tmp_path)
+
+    assert result is not None
+    assert result.file_hash == matching_hash
+    mock_warning.assert_not_called()
+
+
+@patch('codeweaver.core.utils.filesystem.get_project_path')
+@patch('codeweaver.core.discovery.ExtCategory.from_file')
+def test_from_path_project_path_injected(mock_from_file, mock_get_project_path, tmp_path: Path) -> None:
+    """Test from_path correctly handles the default INJECTED project_path."""
+    real_ext = ExtCategory(language=SemanticSearchLanguage.PYTHON, kind=ChunkKind.CODE)
+    mock_from_file.return_value = real_ext
+
+    # Mock get_project_path since it will be called when project_path is INJECTED
+    mock_get_project_path.return_value = tmp_path
+
+    test_file = tmp_path / "src" / "test.py"
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text("content")
+
+    result = DiscoveredFile.from_path(test_file)
+
+    assert result is not None
+    assert result.project_path == tmp_path
+    assert result.path == Path("src/test.py")
+
+
+@patch('codeweaver.core.discovery.ExtCategory.from_file')
+def test_from_path_project_path_explicit(mock_from_file, tmp_path: Path) -> None:
+    """Test from_path correctly handles an explicitly provided project_path."""
+    real_ext = ExtCategory(language=SemanticSearchLanguage.PYTHON, kind=ChunkKind.CODE)
+    mock_from_file.return_value = real_ext
+
+    explicit_project_path = tmp_path / "explicit_project"
+    explicit_project_path.mkdir()
+
+    test_file = explicit_project_path / "src" / "test.py"
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text("content")
+
+    result = DiscoveredFile.from_path(test_file, project_path=explicit_project_path)
+
+    assert result is not None
+    assert result.project_path == explicit_project_path
+    assert result.path == Path("src/test.py")


### PR DESCRIPTION
🎯 **What:** The `from_path` classmethod inside `DiscoveredFile` had various conditional paths (e.g. hash mismatching, git branch fallback, `is_dir()` ternary, `INJECTED` default parameter handling) that lacked dedicated unit tests. 

📊 **Coverage:** The test suite for `test_discovery.py` has been updated to explicitly cover:
- Returns `None` when `ExtCategory.from_file` evaluates to `None`.
- `is_dir()` versus `parent` path behaviors for `get_git_branch`.
- Fallback logic to `'main'` when no git branch is determined.
- Warning logging when user-supplied `file_hash` mismatches the computed hash.
- Logic execution when `project_path` is the default `INJECTED` versus an explicit override.

✨ **Result:** Enhanced the core discovery tests resulting in improved test coverage around file ingestion boundary cases.

---
*PR created automatically by Jules for task [4866958661061906594](https://jules.google.com/task/4866958661061906594) started by @bashandbone*

## Summary by Sourcery

Expand unit coverage of DiscoveredFile.from_path for edge cases around project path resolution, git branch detection, and file hash handling.

Tests:
- Add tests for DiscoveredFile.from_path when ExtCategory.from_file returns None.
- Add tests covering git branch resolution for directory vs file paths and fallback to the 'main' branch when none is detected.
- Add tests verifying warning and behavior when a provided file hash mismatches or matches the computed hash.
- Add tests for handling of default (injected) vs explicitly provided project_path values in DiscoveredFile.from_path.