### PR TITLE
⚡ Bolt: [performance improvement] Optimize Bedrock requests list appending

### DIFF
--- a/src/codeweaver/providers/embedding/providers/bedrock.py
+++ b/src/codeweaver/providers/embedding/providers/bedrock.py
@@ -659,12 +659,12 @@ class BedrockEmbeddingProvider(EmbeddingProvider[BedrockRuntimeClient]):
                 "embedding_types": self._model_config.get("embedding_types", ["float"]),
                 **body_kwargs,
             })
-            requests.extend([
+            requests.append(
                 BedrockInvokeEmbeddingRequest.model_validate({
                     "body": body,
                     "model_id": self._model_arn,
                 })
-            ])
+            )
         return [InvokeRequestDict(**dict(req.model_dump(by_alias=True))) for req in requests]  # ty: ignore[missing-typed-dict-key]
 
     async def _create_request(


### PR DESCRIPTION
💡 What: Replaced `requests.extend([BedrockInvokeEmbeddingRequest.model_validate(...)])` with `requests.append(BedrockInvokeEmbeddingRequest.model_validate(...))` in `BedrockEmbeddingProvider._prepare_request_body`.
🎯 Why: In Python, using `.extend()` with a single-element list inside a loop creates an unnecessary list object and iterates over it, which introduces overhead. Using `.append()` directly is faster and more memory-efficient.
📊 Impact: Minor reduction in memory allocations and CPU overhead when preparing embedding requests for the Bedrock provider.
🔬 Measurement: Verify the change using code review. `mise //:test tests/unit/providers/embedding/` runs successfully without regressions.

---
*PR created automatically by Jules for task [10880826411931631398](https://jules.google.com/task/10880826411931631398) started by @bashandbone*

## Summary by Sourcery

Enhancements:
- Replace single-element list extension with direct append when building Bedrock embedding invoke request list to reduce overhead.