### PR TITLE
🧹 [Code Health] Rename `_check_family_dimension_validation` and its arguments

### DIFF
--- a/tests/unit/providers/embedding/capabilities/test_model_family.py
+++ b/tests/unit/providers/embedding/capabilities/test_model_family.py
@@ -230,42 +230,41 @@ class TestValidateDimensions:
 
     def test_mismatched_embed_dimension(self) -> None:
         """Test that mismatched embed dimension fails validation."""
-        self._check_family_dimension_validation(
+        self._assert_dimension_validation_fails(
             512, 1024, "Embedding dimension 512 does not match query dimension 1024"
         )
 
     def test_mismatched_query_dimension(self) -> None:
         """Test that mismatched query dimension fails validation."""
-        self._check_family_dimension_validation(
+        self._assert_dimension_validation_fails(
             1024, 512, "Embedding dimension 1024 does not match query dimension 512"
         )
 
     def test_embed_and_query_dimensions_mismatch_each_other(self) -> None:
         """Test that embed and query dimensions must match each other."""
-        self._check_family_dimension_validation(
+        self._assert_dimension_validation_fails(
             768, 512, "Embedding dimension 768 does not match query dimension 512"
         )
 
     def test_both_dimensions_wrong_but_match_each_other(self) -> None:
         """Test that even if embed and query match, they must match family."""
-        self._check_family_dimension_validation(
+        self._assert_dimension_validation_fails(
             512,
             512,
             "Embedding dimension 512 is not supported by this family; expected one of (2048, 1024)",
         )
 
-    # TODO Rename this here and in `test_mismatched_embed_dimension`, `test_mismatched_query_dimension`, `test_embed_and_query_dimensions_mismatch_each_other` and `test_both_dimensions_wrong_but_match_each_other`
-    def _check_family_dimension_validation(self, arg0, arg1, arg2):
+    def _assert_dimension_validation_fails(self, embed_dim: int, query_dim: int, expected_error: str) -> None:
         family = ModelFamily(
             family_id="test-family",
             default_dimension=1024,
             output_dimensions=(2048, 1024),
             member_models=frozenset({"model-a"}),
         )
-        is_valid, error = family.validate_dimensions(arg0, arg1)
+        is_valid, error = family.validate_dimensions(embed_dim, query_dim)
         assert is_valid is False
         assert error is not None
-        assert arg2 in error
+        assert expected_error in error
 
     def test_various_dimension_sizes(self) -> None:
         """Test validation with various common dimension sizes."""

--- a/uv.lock
+++ b/uv.lock
@@ -923,7 +923,7 @@ requires-dist = [
     { name = "fastembed-gpu", marker = "python_full_version < '3.14' and extra == 'fastembed-gpu'" },
     { name = "fastembed-gpu", marker = "python_full_version < '3.14' and extra == 'full-gpu'" },
     { name = "fastembed-gpu", marker = "python_full_version < '3.14' and extra == 'gpu-support'" },
-    { name = "fastmcp", specifier = ">=3.0.0" },
+    { name = "fastmcp", specifier = ">=3.0.0,<4.0.0" },
     { name = "google-genai", specifier = "==1.56.0" },
     { name = "huggingface-hub", specifier = ">=1.0.0" },
     { name = "lateimport", specifier = ">=0.1.0" },


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
A TODO was left in `tests/unit/providers/embedding/capabilities/test_model_family.py` to rename `_check_family_dimension_validation` to something more appropriate.

💡 **Why:** How this improves maintainability
Renaming `_check_family_dimension_validation` to `_assert_dimension_validation_fails` clarifies its intention as an assertion method rather than a boolean check or return function. In addition, the generic argument names `arg0`, `arg1`, `arg2` were renamed to `embed_dim`, `query_dim`, and `expected_error` which makes the test much clearer and more understandable.

✅ **Verification:** How you confirmed the change is safe
Ran `uv run pytest tests/unit/providers/embedding/capabilities/test_model_family.py` to assert that all tests still pass and ran `uv run ruff check` to ensure code styling conforms to project standards.

✨ **Result:** The improvement achieved
Improved test code readability and removed a TODO comment.

---
*PR created automatically by Jules for task [12875471147137752857](https://jules.google.com/task/12875471147137752857) started by @bashandbone*

## Summary by Sourcery

Improve readability of embedding model family dimension validation tests by renaming a shared helper and its arguments to better reflect their purpose.

Enhancements:
- Rename the private test helper to clarify that it asserts dimension validation failures rather than returning a boolean.
- Rename the helper’s positional arguments to descriptive names for embedding dimension, query dimension, and expected error message.