### PR TITLE
⚡ Bolt: Optimize constant literal from list to tuple in logger loop

### DIFF
--- a/src/codeweaver/main.py
+++ b/src/codeweaver/main.py
@@ -70,7 +70,7 @@ def _setup_logging_filters(*, verbose: bool, debug: bool) -> None:
         access_filter = UvicornAccessLogFilter()
         logging.getLogger().addFilter(access_filter)
 
-        for logger_name in ["uvicorn", "uvicorn.access", "uvicorn.error"]:
+        for logger_name in ("uvicorn", "uvicorn.access", "uvicorn.error"):
             logger_obj = logging.getLogger(logger_name)
             logger_obj.setLevel(logging.CRITICAL)
             logger_obj.handlers.clear()

--- a/uv.lock
+++ b/uv.lock
@@ -923,7 +923,7 @@ requires-dist = [
     { name = "fastembed-gpu", marker = "python_full_version < '3.14' and extra == 'fastembed-gpu'" },
     { name = "fastembed-gpu", marker = "python_full_version < '3.14' and extra == 'full-gpu'" },
     { name = "fastembed-gpu", marker = "python_full_version < '3.14' and extra == 'gpu-support'" },
-    { name = "fastmcp", specifier = ">=3.0.0" },
+    { name = "fastmcp", specifier = ">=3.0.0,<4.0.0" },
     { name = "google-genai", specifier = "==1.56.0" },
     { name = "huggingface-hub", specifier = ">=1.0.0" },
     { name = "lateimport", specifier = ">=0.1.0" },


### PR DESCRIPTION
💡 **What:** Replaced the list literal `["uvicorn", "uvicorn.access", "uvicorn.error"]` with a tuple literal `("uvicorn", "uvicorn.access", "uvicorn.error")` in `src/codeweaver/main.py`.

🎯 **Why:** While modern CPython implements peephole optimizations that automatically fold constant lists within a `for ... in ...` loop into a tuple, changing this literal explicitly reflects the intended immutability and avoids creating the list object when evaluating the expression directly.

📊 **Measured Improvement:** The `dis` module confirmed that both `[1, 2, 3]` and `(1, 2, 3)` within a loop are precompiled into a static constant `(1, 2, 3)` loaded via `LOAD_CONST` with identical bytecode instructions. Timeit benchmarks verified the execution duration is practically identical. However, adopting the tuple syntax conveys immutability correctly without relying solely on CPython's implicit compiler optimizations.

---
*PR created automatically by Jules for task [7816263455788117927](https://jules.google.com/task/7816263455788117927) started by @bashandbone*

## Summary by Sourcery

Enhancements:
- Use a tuple literal for the constant set of Uvicorn logger names when configuring logging filters.