### PR TITLE
fix: defer fastembed import errors to use time instead of import time

### DIFF
--- a/src/codeweaver/providers/embedding/fastembed_extensions.py
+++ b/src/codeweaver/providers/embedding/fastembed_extensions.py
@@ -15,7 +15,7 @@ from codeweaver.core.utils import has_package
 
 _FASTEMBED_AVAILABLE = has_package("fastembed") or has_package("fastembed-gpu")
 
-if TYPE_CHECKING or _FASTEMBED_AVAILABLE:
+if TYPE_CHECKING:
     from fastembed.common.model_description import (
         BaseModelDescription,
         DenseModelDescription,
@@ -26,7 +26,21 @@ if TYPE_CHECKING or _FASTEMBED_AVAILABLE:
     from fastembed.rerank.cross_encoder import TextCrossEncoder
     from fastembed.sparse import SparseTextEmbedding
     from fastembed.text import TextEmbedding
-else:
+elif _FASTEMBED_AVAILABLE:
+    try:
+        from fastembed.common.model_description import (
+            BaseModelDescription,
+            DenseModelDescription,
+            ModelSource,
+            PoolingType,
+        )
+        from fastembed.rerank.cross_encoder import TextCrossEncoder
+        from fastembed.sparse import SparseTextEmbedding
+        from fastembed.text import TextEmbedding
+    except ImportError:
+        _FASTEMBED_AVAILABLE = False
+
+if not (TYPE_CHECKING or _FASTEMBED_AVAILABLE):
     BaseModelDescription = Any
     DenseModelDescription = Any
     ModelSource = Any
@@ -43,7 +57,7 @@ def _require_fastembed() -> None:
 
         raise ConfigurationError(
             "fastembed is not installed. Please install it with "
-            "`pip install code-weaver[fastembed]` or `codeweaver[fastembed-gpu]`."
+            "`pip install code-weaver[fastembed]` or `pip install code-weaver[fastembed-gpu]`."
         )
 
 

--- a/src/codeweaver/providers/embedding/providers/fastembed.py
+++ b/src/codeweaver/providers/embedding/providers/fastembed.py
@@ -40,7 +40,7 @@ from codeweaver.providers.embedding.providers.base import (
 
 _FASTEMBED_AVAILABLE = has_package("fastembed") or has_package("fastembed-gpu")
 
-if TYPE_CHECKING or _FASTEMBED_AVAILABLE:
+if TYPE_CHECKING:
     from fastembed.sparse import SparseTextEmbedding
     from fastembed.text import TextEmbedding
 
@@ -48,7 +48,19 @@ if TYPE_CHECKING or _FASTEMBED_AVAILABLE:
         get_sparse_embedder,
         get_text_embedder,
     )
-else:
+elif _FASTEMBED_AVAILABLE:
+    try:
+        from fastembed.sparse import SparseTextEmbedding
+        from fastembed.text import TextEmbedding
+
+        from codeweaver.providers.embedding.fastembed_extensions import (
+            get_sparse_embedder,
+            get_text_embedder,
+        )
+    except ImportError:
+        _FASTEMBED_AVAILABLE = False
+
+if not (TYPE_CHECKING or _FASTEMBED_AVAILABLE):
     TextEmbedding = Any
     SparseTextEmbedding = Any
 
@@ -58,6 +70,17 @@ if _FASTEMBED_AVAILABLE:
 else:
     _TextEmbedding = None
     _SparseTextEmbedding = None
+
+
+def _require_fastembed() -> None:
+    """Raise ConfigurationError if fastembed is not installed."""
+    if not _FASTEMBED_AVAILABLE:
+        from codeweaver.core import ConfigurationError
+
+        raise ConfigurationError(
+            "fastembed is not installed. Please install it with "
+            "`pip install code-weaver[fastembed]` or `pip install code-weaver[fastembed-gpu]`."
+        )
 
 
 logger = logging.getLogger(__name__)
@@ -113,6 +136,7 @@ class FastEmbedEmbeddingProvider(EmbeddingProvider[TextEmbedding]):
         **kwargs: Any,
     ) -> None:
         """Initialize the FastEmbed client."""
+        _require_fastembed()
 
     @property
     def base_url(self) -> str | None:
@@ -180,6 +204,7 @@ class FastEmbedSparseProvider(SparseEmbeddingProvider[SparseTextEmbedding]):
         **kwargs: Any,
     ) -> None:
         """Initialize the FastEmbed sparse client."""
+        _require_fastembed()
         # impl_deps and custom_deps are ignored for FastEmbed sparse provider;
         # caps may be passed as a keyword argument via **kwargs from the base class.
         # 1. Set caps using object.__setattr__ because pydantic model isn't fully initialized yet

--- a/src/codeweaver/providers/reranking/providers/fastembed.py
+++ b/src/codeweaver/providers/reranking/providers/fastembed.py
@@ -25,10 +25,27 @@ logger = logging.getLogger(__name__)
 
 _FASTEMBED_AVAILABLE = has_package("fastembed") or has_package("fastembed-gpu")
 
-if TYPE_CHECKING or _FASTEMBED_AVAILABLE:
+if TYPE_CHECKING:
     from fastembed.rerank.cross_encoder import TextCrossEncoder
-else:
+elif _FASTEMBED_AVAILABLE:
+    try:
+        from fastembed.rerank.cross_encoder import TextCrossEncoder
+    except ImportError:
+        _FASTEMBED_AVAILABLE = False
+
+if not (TYPE_CHECKING or _FASTEMBED_AVAILABLE):
     TextCrossEncoder = Any
+
+
+def _require_fastembed() -> None:
+    """Raise ConfigurationError if fastembed is not installed."""
+    if not _FASTEMBED_AVAILABLE:
+        from codeweaver.core import ConfigurationError
+
+        raise ConfigurationError(
+            "fastembed is not installed. Please install it with "
+            "`pip install code-weaver[fastembed]` or `pip install code-weaver[fastembed-gpu]`."
+        )
 
 
 class FastEmbedRerankingProvider(RerankingProvider[TextCrossEncoder]):
@@ -50,6 +67,7 @@ class FastEmbedRerankingProvider(RerankingProvider[TextCrossEncoder]):
         **kwargs: Any,
     ) -> Any:
         """Execute the reranking process."""
+        _require_fastembed()
         try:
             # our batch_size needs to be the number of documents because we only get back the scores.
             # If we set it to a lower number, we wouldn't know what documents the scores correspond to without some extra setup.


### PR DESCRIPTION
## Summary

- Replace import-time `ConfigurationError` raises with conditional imports using `has_package()` sentinels, following the existing pattern in `service_cards.py`
- Modules can now be safely imported when fastembed is unavailable — errors are deferred to the point where fastembed functionality is actually invoked
- Applies the fix consistently across all 3 affected files: `fastembed_extensions.py`, `embedding/providers/fastembed.py`, and `reranking/providers/fastembed.py`

## Approach

Each file follows the same pattern:

1. **Sentinel check** — `_FASTEMBED_AVAILABLE = has_package("fastembed") or has_package("fastembed-gpu")`
2. **Conditional import** — real imports under `TYPE_CHECKING or _FASTEMBED_AVAILABLE`, `Any` placeholders in the `else` branch
3. **Use-time guard** — `_require_fastembed()` raises `ConfigurationError` only when fastembed features are actually called

This mirrors the lazy import convention already used in `service_cards.py` and keeps type checking fully functional.

## Test plan

- [ ] Import chain no longer raises when fastembed is not installed
- [ ] Python 3.14 test collection succeeds (fastembed-specific tests skipped via `requires_fastembed` marker)
- [ ] Existing tests pass when fastembed IS installed — no behavior change
- [ ] `ConfigurationError` is still raised with a clear message when fastembed functionality is invoked without the package

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Defer FastEmbed dependency errors from import time to use time across embedding and reranking providers, allowing the package to be imported without FastEmbed installed while still failing clearly when FastEmbed-backed functionality is invoked.

Bug Fixes:
- Prevent import-time failures when FastEmbed is not installed by guarding FastEmbed-dependent code with runtime availability checks in embedding and reranking providers.

Enhancements:
- Introduce shared FastEmbed availability sentinels and lazy-loading patterns in embedding extensions and providers to align with existing lazy import conventions.