### PR TITLE
⚡ Bolt: Combine keyword delimiters into single regex pattern

### DIFF
--- a/src/codeweaver/engine/chunker/delimiter.py
+++ b/src/codeweaver/engine/chunker/delimiter.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import logging
 import re
 
+from collections import defaultdict
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple, cast
@@ -464,11 +465,9 @@ class DelimiterChunker(BaseChunker):
 
         # Optimization: combining multiple keyword delimiters into a single compiled regex pattern
         # using alternation (?:...) avoids looping over keywords with individual re.finditer calls.
-
-        # Build map of start strings to lists of delimiters to handle collisions
-        # e.g. 'type' or 'extension' being used for multiple structures
-        from collections import defaultdict
-        delimiter_map = defaultdict(list)
+        # Use defaultdict(list) to support multiple delimiters sharing the same start string
+        # (e.g., "type" matches both STRUCT and TYPE_ALIAS patterns).
+        delimiter_map: defaultdict[str, list[Delimiter]] = defaultdict(list)
         for d in keyword_delimiters:
             delimiter_map[d.start].append(d)
 
@@ -478,43 +477,44 @@ class DelimiterChunker(BaseChunker):
             keyword_pos = match.start()
             matched_text = match.group(0)
 
-            for delimiter in delimiter_map[matched_text]:
-                # Skip if keyword is inside a string or comment
-                if self._is_inside_string_or_comment(content, keyword_pos):
-                    continue
+            # Skip if keyword is inside a string or comment (same position for all delimiters)
+            if self._is_inside_string_or_comment(content, keyword_pos):
+                continue
 
-                # Find the next structural opening after the keyword
-                struct_start, struct_char = self._find_next_structural_with_char(
-                    content,
-                    start=keyword_pos + len(delimiter.start),
-                    allowed=set(structural_pairs.keys()),
-                )
+            # Find the next structural opening after the keyword.
+            # All delimiters sharing this start string have the same length, so we compute once.
+            struct_start, struct_char = self._find_next_structural_with_char(
+                content,
+                start=keyword_pos + len(matched_text),
+                allowed=set(structural_pairs.keys()),
+            )
 
-                if struct_start is None:
-                    continue
+            if struct_start is None:
+                continue
 
-                # Find the matching closing delimiter for the structural character
-                struct_end = self._find_matching_close(
-                    content,
-                    struct_start,
-                    struct_char or "",
-                    structural_pairs.get(cast(str, struct_char), ""),
-                )
+            # Find the matching closing delimiter for the structural character
+            struct_end = self._find_matching_close(
+                content,
+                struct_start,
+                struct_char or "",
+                structural_pairs.get(cast(str, struct_char), ""),
+            )
 
-                if struct_end is not None:
-                    # Calculate nesting level by counting parent structures
-                    nesting_level = self._calculate_nesting_level(content, keyword_pos)
+            if struct_end is not None:
+                # Calculate nesting level by counting parent structures
+                nesting_level = self._calculate_nesting_level(content, keyword_pos)
 
-                    # Create a complete match from keyword to closing structure
-                    # This represents the entire construct (e.g., function...})
-                    matches.append(
-                        DelimiterMatch(
-                            delimiter=delimiter,
-                            start_pos=keyword_pos,
-                            end_pos=struct_end,
-                            nesting_level=nesting_level,
-                        )
+                # Create a complete match for every delimiter that shares this start string
+                # (e.g., both STRUCT and TYPE_ALIAS for "type")
+                matches.extend(
+                    DelimiterMatch(
+                        delimiter=delimiter,
+                        start_pos=keyword_pos,
+                        end_pos=struct_end,
+                        nesting_level=nesting_level,
                     )
+                    for delimiter in delimiter_map[matched_text]
+                )
 
         return matches
 


### PR DESCRIPTION
💡 What: Optimize the `_match_keyword_delimiters` method by combining multiple keyword delimiters into a single compiled regex pattern.
🎯 Why: Previously, the engine iterated over every registered keyword delimiter and scanned the entire document string with a separate regex `re.finditer` for each one, resulting in O(K * N) complexity. By combining them using alternation `(?:...)` and looking up the matching delimiter from a dictionary, the regex engine only needs to scan the document exactly once, lowering the text scanning to O(N).
📊 Impact: Considerably faster document text chunking time due to fewer string reads, especially for large source code files with multiple delimiters.
🔬 Measurement: Verify tests run smoothly without regressions on the chunker code via `uv run pytest tests/unit/engine/chunker`.

---
*PR created automatically by Jules for task [15926007155550964703](https://jules.google.com/task/15926007155550964703) started by @bashandbone*

## Summary by Sourcery

Optimize keyword delimiter matching in the chunker to reduce redundant regex scans and improve performance when processing source content.

Enhancements:
- Combine multiple keyword delimiters into a single compiled regex pattern to scan the document once instead of per-delimiter iterations.
- Skip keyword delimiter processing early when no non-empty keyword delimiters are present.

Documentation:
- Fix a minor typo in the language normalization parameter description in the delimiter loader.