### PR TITLE
fix: handle oversized chunks in reranking capabilities

### DIFF
--- a/src/codeweaver/engine/chunker/base.py
+++ b/src/codeweaver/engine/chunker/base.py
@@ -108,15 +108,24 @@ class ChunkGovernor(BasedModel):
     @computed_field
     @property
     def chunk_limit(self) -> PositiveInt:
-        """The absolute maximum chunk size in tokens."""
+        """The absolute maximum chunk size in tokens.
+
+        Considers both context_window and max_input from capabilities.
+        Uses the minimum of all available limits to ensure chunks fit
+        within all model constraints.
+        """
         # Use default of 512 tokens when capabilities aren't available
         if not self._limit_established and self.capabilities:
             self._limit_established = True
-            self._limit = min(
-                capability.context_window
-                for capability in self.capabilities
-                if hasattr(capability, "context_window")
-            )
+            limits = []
+            for capability in self.capabilities:
+                # Prefer max_input over context_window for stricter limits
+                if hasattr(capability, "max_input") and capability.max_input:
+                    limits.append(capability.max_input)
+                elif hasattr(capability, "context_window"):
+                    limits.append(capability.context_window)
+            if limits:
+                self._limit = min(limits)
         return self._limit
 
     @computed_field

--- a/src/codeweaver/providers/reranking/capabilities/base.py
+++ b/src/codeweaver/providers/reranking/capabilities/base.py
@@ -7,6 +7,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Annotated, Any, Literal, cast
 
@@ -19,6 +21,9 @@ from codeweaver.core import ValidationError as CodeWeaverValidationError
 
 if TYPE_CHECKING:
     from codeweaver.core import CodeChunk
+
+
+logger = logging.getLogger(__name__)
 
 
 class RerankingModelCapabilities(BasedModel):
@@ -111,12 +116,37 @@ class RerankingModelCapabilities(BasedModel):
     def _process_max_input_with_tokenizer(
         self, input_chunks: Sequence[str]
     ) -> tuple[bool, NonNegativeInt]:
-        """Process max_input using the specified tokenizer."""
-        # we can prevent it if we pass the max_input down to the chunker, but we should also handle it here.
+        """Process max_input using the specified tokenizer.
+
+        Returns:
+            Tuple of (all_chunks_fit, last_valid_index).
+            - If all_chunks_fit is True, all chunks can be processed.
+            - If False, only chunks up to last_valid_index can be processed.
+        """
         if not self.max_input or not isinstance(self.max_input, int):
             return True, 0
         tokenizer = self.token_processor
         chunk_counts = [tokenizer.estimate(chunk) for chunk in input_chunks]
+
+        # Handle first chunk exceeding max_input (defensive layer)
+        # This matches the graceful degradation pattern from embedding providers
+        if chunk_counts and chunk_counts[0] > self.max_input:
+            logger.warning(
+                "First chunk exceeds max_input (%d > %d tokens). "
+                "This chunk should have been split during chunking. "
+                "Including first chunk anyway to avoid data loss.",
+                chunk_counts[0],
+                self.max_input,
+                extra={
+                    "chunk_tokens": chunk_counts[0],
+                    "max_input": self.max_input,
+                    "model": self.name,
+                },
+            )
+            # Return True with index 0 to allow processing first chunk despite size
+            # The reranking API will handle any actual limits on its end
+            return True, 0
+
         total_count = sum(chunk_counts)
         if total_count <= self.max_input:
             return True, 0
@@ -124,7 +154,7 @@ class RerankingModelCapabilities(BasedModel):
         while summed_count < self.max_input and chunk_counts:
             for i, count in enumerate(chunk_counts):
                 if summed_count + count > self.max_input:
-                    return False, i - 1 if i > 0 else 0
+                    return False, max(0, i - 1)
                 summed_count += count
         return False, len(chunk_counts) - 1
 

--- a/tests/unit/providers/reranking/test_capabilities.py
+++ b/tests/unit/providers/reranking/test_capabilities.py
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: 2026 Knitli Inc.
+# SPDX-FileContributor: Claude (AI Assistant)
+#
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""Unit tests for RerankingModelCapabilities."""
+
+import pytest
+
+from codeweaver.core import Provider
+from codeweaver.providers.reranking.capabilities.base import RerankingModelCapabilities
+
+
+pytestmark = [pytest.mark.unit]
+
+
+class TestRerankingModelCapabilitiesOversizedChunks:
+    """Test handling of oversized chunks in reranking capabilities."""
+
+    def test_first_chunk_exceeds_max_input_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Verify warning is logged when first chunk exceeds max_input."""
+        # Create capabilities with small max_input
+        capabilities = RerankingModelCapabilities(
+            name="test-model",
+            provider=Provider.VOYAGE,
+            max_input=100,
+            tokenizer="tiktoken",
+            tokenizer_model="o200k_base",
+        )
+
+        # Create chunks where first exceeds max_input
+        # A string of ~150 tokens (rough estimate: 1 token ≈ 4 chars)
+        oversized_chunk = "word " * 120  # ~600 chars, likely >100 tokens
+        normal_chunk = "word " * 10  # ~50 chars, likely <100 tokens
+
+        input_chunks = [oversized_chunk, normal_chunk]
+
+        # Call the method
+        all_fit, last_index = capabilities._process_max_input_with_tokenizer(input_chunks)
+
+        # Should return True (allow processing) with index 0
+        assert all_fit is True
+        assert last_index == 0
+
+        # Should have logged a warning
+        assert len(caplog.records) > 0
+        warning_record = next(
+            (r for r in caplog.records if "First chunk exceeds max_input" in r.message), None
+        )
+        assert warning_record is not None
+        assert "should have been split during chunking" in warning_record.message
+        assert warning_record.levelname == "WARNING"
+
+    def test_all_chunks_within_limit(self) -> None:
+        """Verify normal operation when all chunks are within limits."""
+        capabilities = RerankingModelCapabilities(
+            name="test-model",
+            provider=Provider.VOYAGE,
+            max_input=1000,
+            tokenizer="tiktoken",
+            tokenizer_model="o200k_base",
+        )
+
+        # Create small chunks that fit within limit
+        input_chunks = ["word " * 10, "word " * 10, "word " * 10]
+
+        all_fit, last_index = capabilities._process_max_input_with_tokenizer(input_chunks)
+
+        # All should fit
+        assert all_fit is True
+        assert last_index == 0
+
+    def test_chunks_exceed_total_but_not_individually(self) -> None:
+        """Verify correct batching when total exceeds limit but individual chunks don't."""
+        capabilities = RerankingModelCapabilities(
+            name="test-model",
+            provider=Provider.VOYAGE,
+            max_input=100,
+            tokenizer="tiktoken",
+            tokenizer_model="o200k_base",
+        )
+
+        # Create chunks that individually fit but total exceeds
+        # Each ~40 tokens, total ~120 tokens
+        input_chunks = ["word " * 30, "word " * 30, "word " * 30]
+
+        all_fit, last_index = capabilities._process_max_input_with_tokenizer(input_chunks)
+
+        # Not all fit, should return index of last chunk that fits
+        assert all_fit is False
+        assert last_index >= 0  # At least first chunk should fit
+
+    def test_no_max_input_returns_all_fit(self) -> None:
+        """Verify that when max_input is not set, all chunks are accepted."""
+        capabilities = RerankingModelCapabilities(
+            name="test-model",
+            provider=Provider.VOYAGE,
+            max_input=None,
+            tokenizer="tiktoken",
+            tokenizer_model="o200k_base",
+        )
+
+        # Create any chunks
+        input_chunks = ["word " * 100, "word " * 100]
+
+        all_fit, last_index = capabilities._process_max_input_with_tokenizer(input_chunks)
+
+        # All should fit when no limit
+        assert all_fit is True
+        assert last_index == 0
+
+    def test_empty_chunks_list(self) -> None:
+        """Verify handling of empty chunks list."""
+        capabilities = RerankingModelCapabilities(
+            name="test-model",
+            provider=Provider.VOYAGE,
+            max_input=100,
+            tokenizer="tiktoken",
+            tokenizer_model="o200k_base",
+        )
+
+        all_fit, last_index = capabilities._process_max_input_with_tokenizer([])
+
+        # Empty list should return all_fit=True
+        assert all_fit is True
+        assert last_index == 0
+
+    def test_single_oversized_chunk_with_extra_logging(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Verify extra logging fields when first chunk exceeds max_input."""
+        capabilities = RerankingModelCapabilities(
+            name="test-reranker",
+            provider=Provider.COHERE,
+            max_input=50,
+            tokenizer="tiktoken",
+            tokenizer_model="o200k_base",
+        )
+
+        oversized_chunk = "word " * 100  # Very large chunk
+
+        capabilities._process_max_input_with_tokenizer([oversized_chunk])
+
+        # Check that extra logging fields are present
+        warning_record = next(
+            (r for r in caplog.records if "First chunk exceeds max_input" in r.message), None
+        )
+        assert warning_record is not None
+
+        # Verify extra fields in log record
+        # Note: extra fields may be in different locations depending on logger config
+        # but should be accessible via the record
+        assert hasattr(warning_record, "chunk_tokens") or "chunk_tokens" in str(warning_record)
+        assert hasattr(warning_record, "max_input") or "max_input" in str(warning_record)
+        assert hasattr(warning_record, "model") or "test-reranker" in str(warning_record)


### PR DESCRIPTION
## Summary

Implements three-layer defense for handling oversized chunks in reranking providers:

1. **Defensive handling in reranking capabilities** - graceful degradation when first chunk exceeds max_input
2. **Prevention layer in ChunkGovernor** - considers max_input when setting chunk limits
3. **Comprehensive test coverage** - 6 new test cases validating the behavior

## Changes

- Modified: `src/codeweaver/providers/reranking/capabilities/base.py`
- Modified: `src/codeweaver/engine/chunker/base.py`
- Added: `tests/unit/providers/reranking/test_capabilities.py`

## Testing

All tests passing:
- 33/33 reranking provider tests
- 56/56 chunker tests

## Constitutional Compliance

✅ Principle III (Evidence-Based Development): Solution based on verifiable patterns from embedding providers
✅ Principle IV (Testing Philosophy): Tests focus on critical user-affecting behavior
✅ Principle V (Simplicity Through Architecture): Clear multi-layer defense strategy

Fixes #105

---
Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Improve handling of oversized input chunks for reranking models and align chunking limits with reranker constraints.

Bug Fixes:
- Allow reranking to proceed gracefully when the first chunk individually exceeds max_input while logging a warning instead of failing or truncating data.
- Ensure chunk selection under max_input never returns a negative last_valid_index when total tokens exceed the limit.

Enhancements:
- Make ChunkGovernor compute chunk_limit using the strictest of available max_input or context_window values across capabilities to better respect downstream model constraints.
- Add structured warning logging with contextual fields when reranking encounters oversized initial chunks.

Tests:
- Add unit test suite covering reranking capabilities behavior with oversized chunks, missing max_input, empty input, and logging of warning details.