### PR TITLE
feat: distribute CodeWeaver as a Claude Code plugin

### DIFF
--- a/.github/ISSUE_TEMPLATE/plugin-contribution.yml
+++ b/.github/ISSUE_TEMPLATE/plugin-contribution.yml
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2025 Knitli Inc.
+#
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+name: Plugin Contribution (Skill or Hook)
+description: Propose or track a new Claude Code plugin skill or hook for CodeWeaver
+title: "[Plugin]: "
+labels: ["plugin", "contribution"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for contributing to the CodeWeaver Claude Code plugin! This template is for proposing or tracking new **Agent Skills** and **Claude Code Hooks**. For general bugs or feature requests, please use the appropriate template instead.
+
+  - type: dropdown
+    id: contribution-type
+    attributes:
+      label: Contribution Type
+      description: Are you proposing a skill or a hook?
+      options:
+        - Agent Skill
+        - Claude Code Hook
+        - Both
+    validations:
+      required: true
+
+  - type: input
+    id: name
+    attributes:
+      label: Name
+      description: A short, descriptive name for the skill or hook (e.g. "architecture-analysis", "pre-search-optimizer")
+      placeholder: my-skill-or-hook-name
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What does this skill or hook do? What problem does it solve?
+      placeholder: Describe the purpose and behavior of this contribution...
+    validations:
+      required: true
+
+  - type: textarea
+    id: behavior
+    attributes:
+      label: Proposed Behavior
+      description: Describe the expected behavior in detail. For skills, describe the workflow. For hooks, describe the trigger and action.
+      placeholder: |
+        For a skill: "When invoked, this skill walks the user through..."
+        For a hook: "On `user-prompt-submit`, this hook checks..."
+
+  - type: textarea
+    id: use-cases
+    attributes:
+      label: Use Cases
+      description: List the primary use cases or user stories this addresses.
+      placeholder: |
+        - As a developer, I want to...
+        - When working on a large codebase, I need...
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Contribution Checklist
+      options:
+        - label: I have searched existing issues to ensure this is not a duplicate
+          required: true
+        - label: This contribution is appropriate for the plugin (not a core CodeWeaver feature)
+          required: true

--- a/codeweaver-plugin/.claude-plugin/plugin.json
+++ b/codeweaver-plugin/.claude-plugin/plugin.json
@@ -28,7 +28,13 @@
         "stdio",
         "--project",
         "${workspaceFolder}"
-      ]
+      ],
+      "env": {
+        "XDG_DATA_HOME": "${CLAUDE_PLUGIN_DATA}/data",
+        "XDG_CACHE_HOME": "${CLAUDE_PLUGIN_DATA}/cache",
+        "XDG_STATE_HOME": "${CLAUDE_PLUGIN_DATA}/state",
+        "XDG_CONFIG_HOME": "${CLAUDE_PLUGIN_DATA}/config"
+      }
     }
   }
 }

--- a/codeweaver-plugin/.claude-plugin/plugin.json.license
+++ b/codeweaver-plugin/.claude-plugin/plugin.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Knitli Inc.
+
+SPDX-License-Identifier: MIT OR Apache-2.0

--- a/codeweaver-plugin/.mcp.json
+++ b/codeweaver-plugin/.mcp.json
@@ -1,15 +1,23 @@
 {
-  "codeweaver": {
-    "command": "uvx",
-    "args": [
-      "--from",
-      "code-weaver",
-      "cw",
-      "server",
-      "--transport",
-      "stdio",
-      "--project",
-      "${workspaceFolder}"
-    ]
+  "mcpServers": {
+    "codeweaver": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "code-weaver",
+        "cw",
+        "server",
+        "--transport",
+        "stdio",
+        "--project",
+        "${workspaceFolder}"
+      ],
+      "env": {
+        "XDG_DATA_HOME": "${CLAUDE_PLUGIN_DATA}/data",
+        "XDG_CACHE_HOME": "${CLAUDE_PLUGIN_DATA}/cache",
+        "XDG_STATE_HOME": "${CLAUDE_PLUGIN_DATA}/state",
+        "XDG_CONFIG_HOME": "${CLAUDE_PLUGIN_DATA}/config"
+      }
+    }
   }
 }

--- a/codeweaver-plugin/.mcp.json.license
+++ b/codeweaver-plugin/.mcp.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Knitli Inc.
+
+SPDX-License-Identifier: MIT OR Apache-2.0

--- a/codeweaver-plugin/README.md
+++ b/codeweaver-plugin/README.md
@@ -45,7 +45,16 @@ CodeWeaver automatically indexes your project on first use. Claude can then sear
 
 ## Storage
 
-CodeWeaver stores its index and cache in `${CLAUDE_PLUGIN_DATA}/codeweaver`, which persists across plugin updates.
+CodeWeaver redirects all storage to the plugin's designated data directory via XDG environment variables set in the plugin configuration:
+
+- **Index data**: `${CLAUDE_PLUGIN_DATA}/state/codeweaver/indexes/`
+- **Vector store**: `${CLAUDE_PLUGIN_DATA}/state/codeweaver/vectors/`
+- **Model cache**: `${CLAUDE_PLUGIN_DATA}/cache/codeweaver/`
+- **Configuration**: `${CLAUDE_PLUGIN_DATA}/config/codeweaver/`
+
+This ensures data persists across plugin updates and is stored in the standard plugin data directory.
+
+> **Note**: XDG directory overrides apply on Linux. On macOS, storage falls back to `~/Library/...` directories unless you configure paths explicitly via `CODEWEAVER_INDEX_STORAGE_PATH` and related settings.
 
 ## Configuration
 
@@ -59,7 +68,7 @@ Default configuration uses:
 ## Requirements
 
 - Python 3.12 or later
-- [uv](https://astral.sh/uv) package manager (bundled with plugin)
+- [uv](https://astral.sh/uv) package manager (must be installed separately; see the [installation guide](https://docs.astral.sh/uv/getting-started/installation/))
 
 ## Support
 

--- a/codeweaver-plugin/hooks/README.md
+++ b/codeweaver-plugin/hooks/README.md
@@ -27,7 +27,7 @@ Claude Code supports several hook types:
 
 ## Contributing
 
-Interested in contributing hooks? See our [onboarding issue](https://github.com/knitli/codeweaver/issues) for planned hooks and contribution guidelines.
+Interested in contributing hooks? Open a [plugin contribution issue](https://github.com/knitli/codeweaver/issues/new?template=plugin-contribution.yml) to propose a new hook or track progress on planned hooks.
 
 ## Structure
 

--- a/codeweaver-plugin/skills/README.md
+++ b/codeweaver-plugin/skills/README.md
@@ -29,7 +29,7 @@ Skills follow the [Agent Skills](https://agentskills.io) open standard, making t
 
 ## Contributing
 
-Interested in contributing skills? See our [onboarding issue](https://github.com/knitli/codeweaver/issues) for planned skills and contribution guidelines.
+Interested in contributing skills? Open a [plugin contribution issue](https://github.com/knitli/codeweaver/issues/new?template=plugin-contribution.yml) to propose a new skill or track progress on planned skills.
 
 ## Structure
 


### PR DESCRIPTION
## Summary
Package CodeWeaver as an installable Claude Code plugin enabling one-command installation.

## Changes
- Added complete plugin directory structure in `codeweaver-plugin/`
- Created plugin manifest with MCP server configuration and XDG environment variable overrides to route all storage into `${CLAUDE_PLUGIN_DATA}`
- Added user-facing documentation
- Set up placeholders for future Agent Skills and hooks
- Added `.github/ISSUE_TEMPLATE/plugin-contribution.yml` for structured skills/hooks contribution tracking

## Plugin Structure
```
codeweaver-plugin/
├── .claude-plugin/
│   └── plugin.json
├── .mcp.json
├── skills/README.md
├── hooks/README.md
└── README.md
```

## Plugin Data Storage
Both `plugin.json` and `.mcp.json` set XDG environment variables so all CodeWeaver storage is redirected to the plugin's designated data directory:

- **Index data**: `${CLAUDE_PLUGIN_DATA}/state/codeweaver/indexes/`
- **Vector store**: `${CLAUDE_PLUGIN_DATA}/state/codeweaver/vectors/`
- **Model cache**: `${CLAUDE_PLUGIN_DATA}/cache/codeweaver/`
- **Configuration**: `${CLAUDE_PLUGIN_DATA}/config/codeweaver/`

> **Note**: XDG overrides apply on Linux. On macOS, storage falls back to `~/Library/...` unless paths are configured explicitly.

## Installation Flow
Once submitted to the marketplace, users can install with:
```bash
/plugin install codeweaver@knitli
```

## Testing
- ✅ Plugin structure follows Claude Code specification
- ✅ MCP configuration uses standard `mcpServers` format
- ✅ Storage correctly redirected to `${CLAUDE_PLUGIN_DATA}` via XDG env vars (verified with `platformdirs` on Linux)
- ✅ Issue template created and contributing links updated to point to it
- ⚠️ Requires marketplace submission for end-to-end testing

Generated with <a href="https://claude.ai/code">Claude Code</a>

## Summary by Sourcery

Package CodeWeaver as an installable Claude Code plugin, including MCP server configuration with plugin data directory integration, and scaffolding for future skills and hooks.

New Features:
- Distribute CodeWeaver as a Claude Code plugin for one-command installation via the marketplace.
- Route all plugin storage (index, vectors, cache, config) into `${CLAUDE_PLUGIN_DATA}` via XDG environment variable overrides.

Documentation:
- Add user-facing README for the CodeWeaver Claude Code plugin describing installation, capabilities, storage layout, configuration, and requirements.
- Add placeholder documentation for future Agent Skills and Claude Code hooks, with contributing links pointing to a structured issue template.
- Add `.github/ISSUE_TEMPLATE/plugin-contribution.yml` for tracking skill and hook contributions.