### PR TITLE
⚡ Bolt: [performance improvement] Optimize extend() list allocations

### DIFF
--- a/src/codeweaver/providers/config/clients/utils.py
+++ b/src/codeweaver/providers/config/clients/utils.py
@@ -28,9 +28,9 @@ def ensure_endpoint_version(url: str, *, cohere: bool = False) -> str:
 def _get_heroku_envs(*, cohere: bool = False) -> tuple[str, ...]:
     envs = ["INFERENCE_URL", "HEROKU_INFERENCE_URL", "HEROKU_BASE_URL"]
     if cohere:
-        envs.extend(["CO_API_URL", "COHERE_BASE_URL", "COHERE_API_BASE"])
+        envs.extend(("CO_API_URL", "COHERE_BASE_URL", "COHERE_API_BASE"))
     else:
-        envs.extend(["OPENAI_API_URL", "OPENAI_API_BASE_URL", "OPENAI_API_BASE"])
+        envs.extend(("OPENAI_API_URL", "OPENAI_API_BASE_URL", "OPENAI_API_BASE"))
     return tuple(envs)
 
 

--- a/src/codeweaver/providers/dependencies/providers.py
+++ b/src/codeweaver/providers/dependencies/providers.py
@@ -359,7 +359,7 @@ async def _create_embedding_providers() -> tuple[EmbeddingProvider, ...]:
             query_provider = await _instantiate_provider_from_settings(
                 settings.query_provider, EmbeddingProvider
             )
-            providers.extend([embed_provider, query_provider])
+            providers.extend((embed_provider, query_provider))
         else:
             provider = await _instantiate_provider_from_settings(settings, EmbeddingProvider)
             providers.append(provider)

--- a/src/codeweaver/providers/reranking/capabilities/cohere.py
+++ b/src/codeweaver/providers/reranking/capabilities/cohere.py
@@ -79,7 +79,6 @@ def get_cohere_reranking_capabilities() -> tuple[CohereRerankingCapabilities, ..
             "rerank-v4.0-fast",
         )
     ]
-    capabilities.extend([])
     return (
         *capabilities,
         CohereRerankingCapabilities.model_validate({


### PR DESCRIPTION
💡 What: Replaced temporary list literals inside `.extend()` calls with tuple literals, and removed a redundant `extend([])` operation.
🎯 Why: In CPython, tuple literals are compiled as constants, meaning `my_list.extend(("A", "B"))` executes faster and uses less memory than `my_list.extend(["A", "B"])`, which must allocate and garbage-collect a new temporary list every time it is evaluated. The removed `extend([])` call was simply a no-op that added unnecessary function overhead.
📊 Impact: Minor speedup and reduced memory allocation per function call. Measurable only across thousands of calls, but fundamentally a cleaner approach.
🔬 Measurement: Verify changes in `src/codeweaver/providers/config/clients/utils.py`, `src/codeweaver/providers/dependencies/providers.py` and `src/codeweaver/providers/reranking/capabilities/cohere.py`. Run `uv run pytest tests/unit/` to ensure no functionality is affected.

---
*PR created automatically by Jules for task [581891312871722207](https://jules.google.com/task/581891312871722207) started by @bashandbone*

## Summary by Sourcery

Optimize list extension patterns for minor performance and memory improvements.

Enhancements:
- Replace temporary list literals in extend() calls with tuple literals to avoid repeated list allocations.
- Remove a no-op extend([]) call from Cohere reranking capabilities construction.