### PR TITLE
Prepare for v0.1.0 release with versioning updates

### DIFF
--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -20,7 +20,7 @@ CodeWeaver is an extensible MCP (Model Context Protocol) server for semantic cod
 - 26 languages with full AST support, 170+ with heuristic chunking
 
 ## Current Status
-**Version**: v0.1 Alpha Release - Early development phase
+**Version**: 0.x early release
 
 **What Works (v0.1)**:
 - Core hybrid search (dense + sparse vectors)

--- a/.specify/memory/di-integration-progress.md
+++ b/.specify/memory/di-integration-progress.md
@@ -7,8 +7,8 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 
 # DI System Integration Progress Report
 
-**Date**: 2026-01-08  
-**Status**: Phases 1-5 Complete, Phase 6+ Pending  
+**Date**: 2026-01-08
+**Status**: Phases 1-5 Complete, Phase 6+ Pending
 **Plan Document**: `.claude/plans/imperative-waddling-manatee.md`
 
 ---
@@ -41,15 +41,15 @@ The dependency injection (DI) system foundation is now complete through Phase 5.
 @dependency_provider(BaseCodeWeaverSettings, scope="singleton")
 def bootstrap_settings() -> BaseCodeWeaverSettings:
     """Bootstrap global settings as DI root.
-    
+
     Auto-detects the appropriate settings class based on installed packages
     (server, engine, provider, or core) and returns it as BaseCodeWeaverSettings.
-    
+
     Returns:
         The appropriate settings instance for the current installation
     """
     from codeweaver.core.config.loader import get_settings
-    
+
     config_file = _resolve_config_file()
     return get_settings(config_file=config_file)
 ```
@@ -195,20 +195,20 @@ All factories follow this structure:
 def _create_[provider]_client() -> [ClientType]:
     """Factory for [Provider] client."""
     from codeweaver.core.di import INJECTED
-    
+
     # Inject primary config
     config: EmbeddingProviderSettingsType = INJECTED  # type: ignore[name-defined]
-    
+
     # Validation
     if not config or not config.client_options:
         raise ConfigurationError("Client factory requires config with client_options")
-    
+
     # Import SDK
     try:
         from [sdk_package] import [ClientClass]
     except ImportError as e:
         raise ConfigurationError('Install package: pip install "code-weaver[[extra]]"') from e
-    
+
     # Extract and apply client options
     client_options = config.client_options.as_settings()
     return [ClientClass](**client_options)
@@ -261,7 +261,7 @@ type SentenceTransformersSparseClientDep = Annotated[
 ```python
 def _get_provider_class_for_config(config: EmbeddingConfigT) -> type:
     """Map embedding config to its provider class.
-    
+
     Supports 15 provider types, including special handling for OpenAI-compatible
     providers (7 providers → 1 base class).
     """
@@ -282,7 +282,7 @@ def _get_provider_class_for_config(config: EmbeddingConfigT) -> type:
         Provider.FASTEMBED: FastEmbedProvider,
         Provider.SENTENCE_TRANSFORMERS: SentenceTransformersProvider,
     }
-    
+
     provider_cls = provider_map.get(config.provider)
     if not provider_cls:
         raise ConfigurationError(f"No provider class for {config.provider}")
@@ -293,7 +293,7 @@ def _get_provider_class_for_config(config: EmbeddingConfigT) -> type:
 ```python
 def _create_client_for_config(config: EmbeddingConfigT) -> Any:
     """Create SDK client for the given config.
-    
+
     Routes to appropriate client factory based on provider type.
     """
     client_factories = {
@@ -301,7 +301,7 @@ def _create_client_for_config(config: EmbeddingConfigT) -> Any:
         Provider.AZURE: _create_openai_client,
         # ... 13 more mappings
     }
-    
+
     factory = client_factories.get(config.provider)
     if not factory:
         raise ConfigurationError(f"No client factory for {config.provider}")
@@ -317,13 +317,13 @@ def _instantiate_provider(
     caps: EmbeddingCapabilities,
 ) -> Any:
     """Instantiate a provider with dependencies.
-    
+
     Args:
         provider_cls: Provider class (may be dynamically created backup class)
         config: Provider configuration
         client: SDK client instance
         caps: Model capabilities
-    
+
     Returns:
         Configured provider instance
     """
@@ -337,35 +337,35 @@ async def create_all_embedding_providers(
     caps_resolver: EmbeddingCapabilityResolverDep = INJECTED,
 ) -> tuple[Any, ...]:
     """Factory for creating ALL embedding providers (primary + backups).
-    
+
     Integrates with backup_factory for dynamic backup class generation.
     """
     from codeweaver.providers.backup_factory import create_backup_class
-    
+
     if not configs:
         return tuple()
-    
+
     providers = []
     for i, config in enumerate(configs):
         is_backup = i > 0
-        
+
         # Get provider class
         provider_cls = _get_provider_class_for_config(config)
-        
+
         # Apply backup wrapper if needed
         if is_backup:
             provider_cls = create_backup_class(provider_cls)
-        
+
         # Create client
         client = _create_client_for_config(config)
-        
+
         # Resolve capabilities
         caps = caps_resolver.resolve(config.model_name)
-        
+
         # Instantiate provider
         provider = _instantiate_provider(provider_cls, config, client, caps)
         providers.append(provider)
-    
+
     return tuple(providers)
 ```
 
@@ -414,7 +414,7 @@ def create_backup_class[T](provider_cls: type[T]) -> type[T]:
     """Create BackupXProvider dynamically."""
     if provider_cls in _backup_class_cache:
         return _backup_class_cache[provider_cls]
-    
+
     backup_base = get_backup_base_class(provider_cls)  # Returns BackupEmbeddingProvider
     backup_cls = type(
         f"Backup{provider_cls.__name__}",
@@ -446,15 +446,15 @@ def create_backup_class[T](provider_cls: type[T]) -> type[T]:
 ```python
 def _parse_config_reference(ref: str) -> tuple[str, int | None]:
     """Parse a config reference into base name and optional index.
-    
+
     Args:
         ref: Config reference string (e.g., "embedding", "embedding[0]", "embedding[*]")
-    
+
     Returns:
         Tuple of (base_name, index) where:
         - base_name: The config kind (e.g., "embedding")
         - index: The index number, -1 for "*" (all), or None for no index
-    
+
     Examples:
         >>> _parse_config_reference("embedding")
         ("embedding", None)
@@ -466,10 +466,10 @@ def _parse_config_reference(ref: str) -> tuple[str, int | None]:
     match = re.match(r"^([a-z_]+)(?:\[(\d+|\*)\])?$", ref)
     if not match:
         return ref, None
-    
+
     base_name = match.group(1)
     index_str = match.group(2)
-    
+
     if index_str is None:
         return base_name, None
     if index_str == "*":
@@ -485,15 +485,15 @@ async def _resolve_indexed_config(
     container: Any,
 ) -> Any | None:
     """Resolve a config dependency with optional indexing.
-    
+
     Args:
         dep_name: Dependency name (may include index like "embedding[0]")
         dep_type: Type to resolve from DI container
         container: DI container instance
-    
+
     Returns:
         Resolved config instance(s) or None if resolution fails
-    
+
     Examples:
         "embedding" → primary config (backward compatible)
         "embedding[0]" → primary config (explicit)
@@ -501,33 +501,33 @@ async def _resolve_indexed_config(
         "embedding[1]" → first backup config
     """
     base_name, index = _parse_config_reference(dep_name)
-    
+
     with contextlib.suppress(AttributeError, KeyError, TypeError, ValueError, ImportError):
         resolved = await container.resolve(dep_type)
-        
+
         # No indexing - return as-is (backward compatible)
         if index is None:
             return resolved
-        
+
         # All configs requested (embedding[*])
         if index == -1:
             if isinstance(resolved, tuple | list):
                 return resolved
             return (resolved,)
-        
+
         # Specific index requested
         if isinstance(resolved, tuple | list):
             try:
                 return resolved[index]
             except IndexError:
                 return None
-        
+
         # Non-collection but index 0 (primary)
         if index == 0:
             return resolved
-        
+
         return None
-    
+
     return None
 ```
 
@@ -535,41 +535,41 @@ async def _resolve_indexed_config(
 ```python
 async def resolve_all_configs() -> None:
     """Resolve all configurations across the application.
-    
+
     Extended in Phase 5 to support indexed config references:
     - "embedding" - resolves to primary config (backward compatible)
     - "embedding[0]" - resolves to primary config (explicit)
     - "embedding[*]" - resolves to all configs (tuple)
     - "embedding[1]" - resolves to first backup config
-    
+
     Example:
         class VectorStoreConfig:
             def config_dependencies(self):
                 return {"embedding[0]": EmbeddingProviderSettings}
-            
+
             async def apply_resolved_config(self, embedding=None, **resolved):
                 if embedding:
                     self._resolved_dimension = await embedding.get_dimension()
     """
     from codeweaver.core.config.registry import get_configurable_components
-    
+
     container = get_container()
-    configurables = get_configurable_components()
-    
-    for configurable in configurables:
+    configurable = get_configurable_components()
+
+    for configurable in configurable:
         deps = configurable.config_dependencies()
         resolved = {}
-        
+
         for dep_name, dep_type in deps.items():
             # Parse and resolve with indexing support
             resolved_config = await _resolve_indexed_config(dep_name, dep_type, container)
-            
+
             if resolved_config is not None:
                 # Strip index from key for apply_resolved_config()
                 # "embedding[0]" becomes "embedding"
                 base_name, _ = _parse_config_reference(dep_name)
                 resolved[base_name] = resolved_config
-        
+
         if resolved:
             await configurable.apply_resolved_config(**resolved)
 ```
@@ -578,25 +578,25 @@ async def resolve_all_configs() -> None:
 ```python
 class ConfigurableComponent(Protocol):
     """Protocol for components participating in config resolution.
-    
+
     Extended in Phase 5 to support indexed config references:
     - "embedding" - primary embedding config (backward compatible)
     - "embedding[0]" - primary embedding config (explicit)
     - "embedding[*]" - all embedding configs (primary + backups)
     - "embedding[1]" - first backup config
     """
-    
+
     def config_dependencies(self) -> dict[str, type]:
         """Return types this config needs to resolve against.
-        
+
         Examples:
             Simple reference (backward compatible):
                 {"embedding": EmbeddingProviderSettings}
-            
+
             Indexed reference (Phase 5):
                 {"embedding[0]": EmbeddingProviderSettings}  # Primary only
                 {"embedding[*]": EmbeddingProviderSettings}  # All configs
-            
+
             Multiple dependencies:
                 {
                     "embedding[0]": EmbeddingProviderSettings,
@@ -604,10 +604,10 @@ class ConfigurableComponent(Protocol):
                 }
         """
         ...
-    
+
     async def apply_resolved_config(self, **resolved: Any) -> None:
         """Apply resolved configuration from dependencies.
-        
+
         Note:
             Indexed references like "embedding[0]" will have the index
             stripped from the key, so you'll receive "embedding" as the key.
@@ -652,10 +652,10 @@ The primary use case is vector stores needing the embedding dimension:
 ```python
 class VectorStoreConfig(ConfigurableComponent):
     """Vector store configuration that depends on embedding dimension."""
-    
+
     def config_dependencies(self) -> dict[str, type]:
         return {"embedding[0]": EmbeddingProviderSettings}  # Primary embedding
-    
+
     async def apply_resolved_config(self, embedding: EmbeddingProviderSettings | None = None, **resolved):
         """Apply resolved embedding config."""
         if embedding:
@@ -786,11 +786,11 @@ __all__ = (
     "RerankingProviderSettingsDep",
     "SparseEmbeddingProviderSettingsDep",
     "VectorStoreProviderSettingsDep",
-    
+
     # Capability Resolver Type Aliases (Phase 2)
     "EmbeddingCapabilityResolverDep",
     "RerankingCapabilityResolverDep",
-    
+
     # Client Type Aliases (Phase 3)
     "BedrockClientDep",
     "ClientDep",
@@ -804,15 +804,15 @@ __all__ = (
     "SentenceTransformersClientDep",
     "SentenceTransformersSparseClientDep",
     "VoyageClientDep",
-    
+
     # Provider Type Aliases (Phase 4)
     "AllEmbeddingProvidersDep",
     "PrimaryEmbeddingProviderDep",
-    
+
     # Factory Functions (Phase 4)
     "create_all_embedding_providers",
     "get_primary_embedding_provider",
-    
+
     # Utilities
     "NoneDep",
 )
@@ -876,10 +876,10 @@ def _create_reranking_client_for_config(config) -> Any:
 async def create_all_reranking_providers() -> tuple[Any, ...]:
     """Factory for all reranking providers (primary + backups)."""
     from codeweaver.providers.backup_factory import create_backup_class
-    
+
     configs: AllRerankingConfigsDep = INJECTED
     caps_resolver: RerankingCapabilityResolverDep = INJECTED
-    
+
     # Similar loop to embedding providers
     # ... implementation
 
@@ -910,11 +910,11 @@ type PrimaryRerankingProviderDep = Annotated[Any, depends(get_primary_reranking_
 
 class BaseVectorStoreConfig(ConfigurableComponent):
     """Vector store config that needs embedding dimension."""
-    
+
     def config_dependencies(self) -> dict[str, type]:
         # Use indexed reference for primary embedding
         return {"embedding[0]": EmbeddingProviderSettings}
-    
+
     async def apply_resolved_config(
         self,
         embedding: EmbeddingProviderSettings | None = None,
@@ -942,14 +942,14 @@ def _get_vector_store_provider_class_for_config(config) -> type:
 async def create_vector_store_provider() -> Any:
     """Factory for vector store provider (single, not collection)."""
     config: VectorStoreProviderSettingsDep = INJECTED
-    
+
     # Vector stores are typically singular, not collections
     provider_cls = _get_vector_store_provider_class_for_config(config)
-    
+
     # Vector stores don't use SDK clients in the same way
     # They may need embedding dimension from config
     provider = provider_cls(config=config)
-    
+
     return provider
 
 type VectorStoreProviderDep = Annotated[Any, depends(create_vector_store_provider)]
@@ -1150,7 +1150,7 @@ Since runtime testing isn't feasible with ~250 broken references, focus on:
 
 ### Phase 8: Deprecate Registry System
 
-**Status**: Not started, planned for ~4th major alpha release
+**Status**: Not started, planned for ~0.4.0
 
 **Current State**:
 The codebase uses a registry system in `src/codeweaver/common/registry/` for provider registration and discovery. This was the pre-DI approach.
@@ -1372,10 +1372,10 @@ async def test_get_all_embedding_configs():
     """Test config collection factory."""
     mock_settings = Mock()
     mock_settings.provider.embedding = (config1, config2)
-    
+
     # Inject mock settings
     result = await get_all_embedding_configs(settings=mock_settings)
-    
+
     assert isinstance(result, tuple)
     assert len(result) == 2
     assert result[0] == config1
@@ -1383,9 +1383,9 @@ async def test_get_all_embedding_configs():
 async def test_get_primary_embedding_config():
     """Test primary config extraction."""
     configs = (config1, config2)
-    
+
     result = await get_primary_embedding_config(all_configs=configs)
-    
+
     assert result == config1
 ```
 
@@ -1398,11 +1398,11 @@ async def test_create_openai_client():
         "api_key": "test-key",
         "base_url": "https://api.openai.com",
     }
-    
+
     # This will need to mock the import
     with patch("openai.AsyncOpenAI") as mock_openai:
         client = _create_openai_client(config=mock_config)
-        
+
         mock_openai.assert_called_once_with(
             api_key="test-key",
             base_url="https://api.openai.com",
@@ -1414,30 +1414,30 @@ async def test_create_openai_client():
 async def test_get_provider_class_for_config():
     """Test provider class mapping."""
     from codeweaver.core import Provider
-    
+
     config = Mock()
     config.provider = Provider.OPENAI
-    
+
     cls = _get_provider_class_for_config(config)
-    
+
     assert cls == OpenAIEmbeddingBase
 
 async def test_create_all_embedding_providers_with_backup():
     """Test provider factory with backup integration."""
     # Mock configs
     configs = (primary_config, backup_config)
-    
+
     # Mock capability resolver
     mock_resolver = Mock()
     mock_resolver.resolve.return_value = mock_caps
-    
+
     # Mock backup factory
     with patch("codeweaver.providers.backup_factory.create_backup_class") as mock_backup:
         providers = await create_all_embedding_providers(
             configs=configs,
             caps_resolver=mock_resolver,
         )
-        
+
         # Verify backup class was created for second provider
         mock_backup.assert_called_once()
         assert len(providers) == 2
@@ -1456,11 +1456,11 @@ async def test_resolve_indexed_config_single():
     """Test indexed resolution with single config."""
     mock_container = Mock()
     mock_container.resolve.return_value = mock_config
-    
+
     # Test backward compatible (no index)
     result = await _resolve_indexed_config("embedding", EmbeddingConfig, mock_container)
     assert result == mock_config
-    
+
     # Test explicit primary
     result = await _resolve_indexed_config("embedding[0]", EmbeddingConfig, mock_container)
     assert result == mock_config
@@ -1469,11 +1469,11 @@ async def test_resolve_indexed_config_collection():
     """Test indexed resolution with config collection."""
     mock_container = Mock()
     mock_container.resolve.return_value = (config1, config2, config3)
-    
+
     # Test get all
     result = await _resolve_indexed_config("embedding[*]", EmbeddingConfig, mock_container)
     assert result == (config1, config2, config3)
-    
+
     # Test get specific backup
     result = await _resolve_indexed_config("embedding[1]", EmbeddingConfig, mock_container)
     assert result == config2
@@ -1486,12 +1486,12 @@ async def test_resolve_indexed_config_collection():
 async def test_full_embedding_provider_chain():
     """Test complete DI resolution: Settings → Config → Client → Provider."""
     from codeweaver.core.di import get_container
-    
+
     container = get_container()
-    
+
     # Should resolve through full chain
     provider = await container.resolve(PrimaryEmbeddingProviderDep)
-    
+
     assert provider is not None
     assert hasattr(provider, "embed")
     assert not provider.is_provider_backup
@@ -1499,22 +1499,22 @@ async def test_full_embedding_provider_chain():
 async def test_backup_provider_creation():
     """Test backup provider discrimination."""
     container = get_container()
-    
+
     all_providers = await container.resolve(AllEmbeddingProvidersDep)
-    
+
     assert len(all_providers) >= 1
     assert not all_providers[0].is_provider_backup
-    
+
     if len(all_providers) > 1:
         assert all_providers[1].is_provider_backup
 
 async def test_cross_config_resolution():
     """Test vector store gets embedding dimension."""
     container = get_container()
-    
+
     # Trigger cross-config resolution
     await resolve_all_configs()
-    
+
     # Verify vector store has dimension
     vs_config = await container.resolve(VectorStoreConfig)
     assert hasattr(vs_config, "_resolved_dimension")
@@ -1554,9 +1554,9 @@ class NewProviderConfig(BaseEmbeddingConfig):
 def _create_newprovider_client() -> Any:
     """Factory for NewProvider SDK client."""
     from codeweaver.core.di import INJECTED
-    
+
     config: EmbeddingProviderSettingsDep = INJECTED
-    
+
     try:
         from newprovider import Client
         return Client(**config.client_options.as_settings())
@@ -1573,7 +1573,7 @@ type NewProviderClientDep = Annotated[Any, depends(_create_newprovider_client)]
 # In src/codeweaver/providers/embedding/providers/newprovider.py
 class NewProviderEmbeddingProvider(EmbeddingProvider):
     """Provider implementation."""
-    
+
     def __init__(
         self,
         config: EmbeddingConfigDep = INJECTED,
@@ -1583,7 +1583,7 @@ class NewProviderEmbeddingProvider(EmbeddingProvider):
         self.config = config
         self.client = client
         self.caps = caps
-    
+
     async def embed(self, texts: list[str]) -> list[list[float]]:
         return await self.client.embed(texts)
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 
 # AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code), Github Copilot, Roo, and other AI agents when working with code in this repository. 
+This file provides guidance to Claude Code (claude.ai/code), Github Copilot, Roo, and other AI agents when working with code in this repository.
 
 ## Project Overview
 
@@ -19,12 +19,12 @@ CodeWeaver is an extensible MCP (Model Context Protocol) server for semantic cod
 - **MCP HTTP Server**: FastMCP at port 9328 for HTTP clients
 - **MCP stdio**: Lightweight proxy that forwards to the HTTP backend (default transport)
 
-**Current Status**: Alpha Release 2. Most core features complete and relatively stable. Advanced functionality planned in several epics.
+**Current Status**: Early release (0.x). Most core features complete and relatively stable. Advanced functionality planned in several epics.
 
 > [!IMPORTANT]
 > Because it is an MCP server, you can use CodeWeaver while assisting with CodeWeaver development!
 > In your list of available tools, you may see `find_code` or `codeweaver__find_code`
-> Congrats! You're both an alpha tester and contributor!
+> Congrats! You're both an early tester and contributor!
 
 ## Project Constitution (DEFINITIVE GUIDANCE)
 
@@ -52,7 +52,7 @@ mise run setup
 # Install dependencies
 mise run sync
 
-# Activate environment  
+# Activate environment
 mise run activate
 ```
 
@@ -307,7 +307,7 @@ src/codeweaver/
 │   │       ├── base.py
 │   │       ├── bedrock.py # AWS Bedrock
 │   │       ├── cohere.py  # also includes Azure and Heroku cohere providers
-│   │       ├── fastembed.py  
+│   │       ├── fastembed.py
 │   │       ├── google.py
 │   │       ├── huggingface.py
 │   │       ├── litellm.py  **scaffolding**
@@ -342,7 +342,7 @@ src/codeweaver/
 │       ├── __init__.py
 │       ├── base.py      # Base vector store interface
 │       ├── inmemory.py  # In-memory vector store (qdrant_client w/ json persistence)
-│       ├── metadata.py  # Vector metadata handling 
+│       ├── metadata.py  # Vector metadata handling
 │       ├── qdrant_base.py # Qdrant base class for all common function to inmemory and qdrant
 │       ├── qdrant.py    # Qdrant vector database (local and cloud/remote)
 │       └── utils.py     # Vector store utilities
@@ -425,7 +425,7 @@ src/codeweaver/
 
 ### Test Categories (via pytest markers)
 - **unit**: Individual component tests
-- **integration**: Component interaction tests  
+- **integration**: Component interaction tests
 - **e2e**: End-to-end workflow tests
 - **benchmark**: Performance tests
 - **network/external_api**: Tests requiring external services
@@ -447,13 +447,13 @@ Apply relevant pytest markers to new tests (see pyproject.toml for full list).
 7. Integrate telemetry and observability
 8. Build comprehensive test suite
 
-### Phase 3: Advanced Orchestration ❌ **Planned for Next Two Major Alpha Releases**
+### Phase 3: Advanced Orchestration ❌ **Planned for Next Two Minor Releases**
 9. Integrate agentic handling of query response (Context agent and Context agent API)
 10. Add Context agent tools
 11. Pluggable pipeline orchestration with `pydantic-graph`
 12. Pipeline/response evaluation and validation with `pydantic-eval`
 13. Expanded testing
-14. Replace registry system with dependency injection pattern, deprecate existing system ~4th major alpha release
+14. Replace registry system with dependency injection pattern, deprecate existing system ~0.4.0
 
 ### Key Implementation Notes
 - Entry point in pyproject.toml: `codeweaver = "codeweaver.cli.app:main"`
@@ -638,9 +638,9 @@ class MyModel(BasedModel)
           FilteredKey("project_path"): AnonymityConversion.HASH, # hashes the value
           # can also be one of BOOLEAN (present/not), COUNT, DISTRIBUTION, AGGREGATE, and TEXT_COUNT
         }
-      
+
     # NOTE: For more complex handling, classes may additionally implement the `_telemetry_handler` method
-    # See `codeweaver.core.types.models.BasedModel` for the API signature. 
+    # See `codeweaver.core.types.models.BasedModel` for the API signature.
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ SPDX-License-Identifier: MIT OR Apache-2.0
   <img alt="CodeWeaver logo" src="docs/assets/codeweaver-primary.webp" height="150px" width="150px">
 </picture>
 
-# CodeWeaver Alpha 6
+# CodeWeaver
 
 ### Exquisite Context for Agents — Infrastructure that is Extensible, Predictable, and Resilient.
 
 [![Python Version][badge_python]][link_python]
 [![License][badge_license]][link_license]
-[![Alpha Release][badge_release]][link_release]
+[![Release][badge_release]][link_release]
 [![MCP Compatible][badge_mcp]][link_mcp]
 
 [Documentation][nav_docs] •
@@ -35,7 +35,7 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 
 **CodeWeaver gives Claude and other AI agents precise context from your codebase.** Not keyword grep. Not whole-file dumps. Actual structural understanding through hybrid semantic search.
 
-CodeWeaver Alpha 6 transforms from a "Search Tool" into **Professional Context Infrastructure**. With 100% Dependency Injection (DI) and a Pydantic-driven configuration system, it provides the reliability and extensibility required for industrial-grade AI deployments.
+CodeWeaver is **Professional Context Infrastructure**. With 100% Dependency Injection (DI) and a Pydantic-driven configuration system, it provides the reliability and extensibility required for industrial-grade AI deployments.
 
 **Example:**
 ```
@@ -49,7 +49,7 @@ With CodeWeaver:
   Result: Precise answers, focused context, 60-80% token reduction
 ```
 
-> ⚠️ **Alpha Release**: CodeWeaver is in active development. [Use it, break it, help shape it][issues].
+> **Early Release (0.x)**: CodeWeaver is in active development. APIs may change between minor versions. [Use it, break it, help shape it][issues].
 
 ---
 
@@ -57,7 +57,7 @@ With CodeWeaver:
 
 ### Quick Reference Matrix
 
-| Feature | CodeWeaver Alpha 6 | Legacy Search Tools |
+| Feature | CodeWeaver | Legacy Search Tools |
 | :--- | :--- | :--- |
 | **Search Type** | Hybrid (Semantic + AST + Keyword) | Keyword Only |
 | **Context Quality** | **Exquisite** / High-Precision | Noisy / Irrelevant |
@@ -171,7 +171,7 @@ AI agents face **too much irrelevant context**, causing token waste, missed patt
 [badge_license]: <https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-green.svg> "License Badge"
 [badge_mcp]: <https://img.shields.io/badge/MCP-compatible-purple.svg> "MCP Compatible Badge"
 [badge_python]: <https://img.shields.io/badge/python-3.12%2B-blue.svg> "Python Version Badge"
-[badge_release]: <https://img.shields.io/badge/release-alpha%205-orange.svg> "Release Badge"
+[badge_release]: <https://img.shields.io/pypi/v/code-weaver.svg> "PyPI Version"
 
 <!-- Other links -->
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,9 +7,9 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 
 # Security
 
-CodeWeaver is **alpha** software. It may have bugs and vulnerabilities, and we do not provide support for any version except the current release.
+CodeWeaver is **pre-1.0** software. It may have bugs and vulnerabilities, and we do not provide support for any version except the current release.
 
-Beta software has bugs, probably lots of them, and some of those may be security vulnerabilities.
+Pre-1.0 software has bugs, probably lots of them, and some of those may be security vulnerabilities.
 
 ## Reporting a Security Concern
 

--- a/docs-site/astro.config.ts
+++ b/docs-site/astro.config.ts
@@ -3,8 +3,10 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 import createConfig from "@knitli/astro-docs-template/config";
+import type { AstroUserConfig } from "astro/config";
 import { DocsAssets } from "@knitli/docs-components"
 import { DocsTemplateOptions } from "@knitli/astro-docs-template/config";
+import { remarkVersion } from "./src/plugins/remark-version";
 
 const { codeweaverPrimary, codeweaverReverse } = DocsAssets;
 
@@ -51,7 +53,7 @@ const configOptions: DocsTemplateOptions = {
         { label: 'Exquisite Context', slug: 'concepts/exquisite-context' },
         { label: 'DI Architecture', slug: 'concepts/di-system' },
         { label: 'Language Support', slug: 'concepts/languages' },
-        { label: 'Roadmap to Alpha 7', slug: 'concepts/roadmap' },
+        { label: 'Roadmap', slug: 'concepts/roadmap' },
       ],
     },
     {
@@ -78,4 +80,13 @@ const configOptions: DocsTemplateOptions = {
   ],
 };
 
-export default createConfig(configOptions);
+const config = createConfig(configOptions) as AstroUserConfig;
+
+// Inject remark-version plugin for {{VERSION}} substitution in markdown
+const existingRemarkPlugins = config.markdown?.remarkPlugins ?? [];
+config.markdown = {
+  ...config.markdown,
+  remarkPlugins: [...existingRemarkPlugins, remarkVersion],
+};
+
+export default config;

--- a/docs-site/src/content/docs/cli.md
+++ b/docs-site/src/content/docs/cli.md
@@ -1,5 +1,5 @@
 ---
-title: CLI Reference (Alpha 6)
+title: CLI Reference
 description: Complete command-line interface reference for CodeWeaver
 ---
 
@@ -8,7 +8,7 @@ description: Complete command-line interface reference for CodeWeaver
 The `cw` command (alias for `codeweaver`) is your primary interface for managing CodeWeaver. It provides tools for initialization, indexing, searching, and diagnostics.
 
 :::note
-Alpha 6 introduces `cw doctor` for deep diagnostics and `cw init --profile` for rapid setup.
+CodeWeaver includes `cw doctor` for deep diagnostics and `cw init --profile` for rapid setup.
 :::
 
 ## Core Workflow
@@ -108,7 +108,7 @@ cw status
 
 ## Configuration
 
-CodeWeaver Alpha 6 uses `codeweaver.toml` as its primary configuration format.
+CodeWeaver uses `codeweaver.toml` as its primary configuration format.
 
 ### File Locations (Priority Order)
 1. **Project Root:** `./codeweaver.toml`

--- a/docs-site/src/content/docs/concepts/di-system.md
+++ b/docs-site/src/content/docs/concepts/di-system.md
@@ -6,7 +6,7 @@ title: "Universal Extensibility: The DI System"
 
 > **TL;DR:** This module handles Universal Extensibility via Dependency Injection (DI). Use it when you need to register services or inject them into functions. It decouples implementation from usage, allowing you to swap providers with zero code changes.
 
-CodeWeaver Alpha 6 uses a lightweight, FastAPI-inspired Dependency Injection (DI) system. This architecture makes the platform extremely extensible—you can swap an embedding provider, a vector store, or even core services by simply updating your configuration.
+CodeWeaver uses a lightweight, FastAPI-inspired Dependency Injection (DI) system. This architecture makes the platform extremely extensible—you can swap an embedding provider, a vector store, or even core services by simply updating your configuration.
 
 ---
 

--- a/docs-site/src/content/docs/concepts/languages.md
+++ b/docs-site/src/content/docs/concepts/languages.md
@@ -4,7 +4,7 @@ title: "Language Support"
 
 # Language Support
 
-> **TL;DR:** CodeWeaver Alpha 6 supports **166+ languages**. Use it to get deep structural context for 27 core languages (AST-aware) or reliable heuristic search for everything else. It saves agents from "context blindness" by understanding the logical boundaries of almost any codebase.
+> **TL;DR:** CodeWeaver supports **166+ languages**. Use it to get deep structural context for 27 core languages (AST-aware) or reliable heuristic search for everything else. It saves agents from "context blindness" by understanding the logical boundaries of almost any codebase.
 
 CodeWeaver is designed to be universal. While it provides the deepest intelligence for modern programming languages, its resilient architecture ensures that even legacy systems or niche configuration formats are searchable and understandable for AI agents.
 

--- a/docs-site/src/content/docs/concepts/roadmap.md
+++ b/docs-site/src/content/docs/concepts/roadmap.md
@@ -1,32 +1,32 @@
 ---
-title: "The Roadmap to Alpha 7"
+title: "Roadmap"
 ---
 
-# The Roadmap to Alpha 7
+# Roadmap
 
-> **TL;DR:** This page handles Alpha Status Transparency. Use it to understand where CodeWeaver is heading. It saves you from surprises by outlining the upcoming transition to a high-performance monorepo structure.
+> **TL;DR:** This page outlines where CodeWeaver is heading. It saves you from surprises by providing transparency on upcoming changes and the path to 1.0.
 
-CodeWeaver Alpha 6 marks the stabilization of our core infrastructure. With the Dependency Injection (DI) system and configuration overhaul complete, we are now preparing for the next major milestone: **The Monorepo Split.**
+CodeWeaver has completed a major infrastructure overhaul. With the Dependency Injection (DI) system and configuration rewrite complete, we are now preparing for the next milestones: **the Monorepo Split** and **Context Agent integration**.
 
 ---
 
-## Current Status: Alpha 6 (Stability)
+## Current Status: 0.1.0 (Stable Foundation)
 
-Alpha 6 is about **Industrial-Grade Context**. We have replaced fragmented registries with a unified, FastAPI-inspired DI system. This ensures that CodeWeaver is no longer just a "search tool," but a professional infrastructure component for AI agents.
+The 0.1.x series represents **Industrial-Grade Context**. We have replaced fragmented registries with a unified, FastAPI-inspired DI system. CodeWeaver is no longer just a "search tool" — it is a professional infrastructure component for AI agents.
 
-**Key Achievements in Alpha 6:**
+**Key Achievements:**
 - **100% DI Integration:** Every service is now registered and injected via the `@dependency_provider` system.
 - **Config Validation:** Pydantic-driven settings catch errors before they reach your agents.
 - **Resilient Pipeline:** Automatic local fallbacks ensure 100% context availability.
 
 ---
 
-## The Next Step: Alpha 7 (Extensibility)
+## Next: 0.2.0 (Extensibility)
 
-The primary goal of Alpha 7 is the **Monorepo Split**. We are reorganizing the codebase into independent, selectively installable packages.
+The primary goal of 0.2.0 is the **Monorepo Split**. We are reorganizing the codebase into independent, selectively installable packages.
 
 ### 1. Package Separation
-Currently, CodeWeaver is a single large package. In Alpha 7, it will be split into:
+Currently, CodeWeaver is a single large package. In 0.2.0, it will be split into:
 - `codeweaver-core`: The base infrastructure, DI container, and logging.
 - `codeweaver-providers`: Embedding, vector store, and agent integrations.
 - `codeweaver-engine`: The indexing and search logic.
@@ -35,17 +35,17 @@ Currently, CodeWeaver is a single large package. In Alpha 7, it will be split in
 ### 2. Selective Installation
 The monorepo structure allows you to install only what you need. If you are building a custom search engine, you might only install `core` and `engine`. If you only need MCP connectivity, you might only install `core` and `server`.
 
-### 3. "Pulling the Bandaid" Refactor
-Alpha 7 completes the architectural cleanup started in Alpha 6. We are removing the last remnants of legacy registries and hardcoded imports, ensuring that each package is truly independent and "monorepo-safe."
+### 3. Legacy Cleanup
+0.2.0 completes the architectural cleanup. We are removing the last remnants of legacy registries and hardcoded imports, ensuring that each package is truly independent and "monorepo-safe."
 
 ---
 
-## Beyond Alpha 7: The Vision
+## The Path to 1.0
 
 Our long-term goal is to establish CodeWeaver as the **Universal Context Layer** for AI.
 
-- **Alpha 8:** Enhanced cloud orchestration and distributed indexing.
-- **Alpha 9:** Multi-tenant support and advanced access controls.
-- **Beta 1:** API stability and performance-at-scale guarantees.
+- **0.3.0:** Context Agent integration and agentic pipeline orchestration.
+- **0.4.0:** Enhanced cloud orchestration and distributed indexing.
+- **1.0.0:** API stability guarantees, performance-at-scale, and production hardening.
 
-We are building CodeWeaver in the open, and we welcome feedback from the community as we transition into this new high-performance architecture.
+We are building CodeWeaver in the open, and we welcome feedback from the community as we move toward a stable 1.0 release.

--- a/docs-site/src/content/docs/guides/configuration.md
+++ b/docs-site/src/content/docs/guides/configuration.md
@@ -4,7 +4,7 @@ title: "Configuration Architecture"
 
 # Configuration Architecture
 
-> **TL;DR:** CodeWeaver Alpha 6 features a completely overhauled configuration system powered by Pydantic. Use it to define your providers, server settings, and performance limits. It catches setup errors at boot-time, ensuring your agent always has a reliable foundation.
+> **TL;DR:** CodeWeaver features a completely overhauled configuration system powered by Pydantic. Use it to define your providers, server settings, and performance limits. It catches setup errors at boot-time, ensuring your agent always has a reliable foundation.
 
 The configuration system is hierarchical, predictable, and strictly validated. Whether you use environment variables, a `.env` file, or a `codeweaver.toml`, the system ensures your settings are consistent before the application starts.
 
@@ -38,7 +38,7 @@ Specific to the CodeWeaver daemon and MCP integration.
 
 ## Validation & Reliability
 
-CodeWeaver Alpha 6 uses **Pydantic V2** to enforce strict validation. This means:
+CodeWeaver uses **Pydantic V2** to enforce strict validation. This means:
 
 1.  **Boot-time Failure:** If you provide an invalid URL or a missing API key, CodeWeaver will fail immediately with a clear error message instead of crashing later during a search.
 2.  **Type Safety:** Numbers, booleans, and nested objects are automatically converted and validated.

--- a/docs-site/src/content/docs/guides/custom-providers.md
+++ b/docs-site/src/content/docs/guides/custom-providers.md
@@ -6,7 +6,7 @@ title: "Custom Providers"
 
 > **TL;DR:** This module handles the registration and implementation of custom providers via the Dependency Injection (DI) system. Use it when you need to integrate a niche embedding model or vector store. It saves development time by allowing you to extend CodeWeaver without modifying the core codebase.
 
-The Dependency Injection (DI) architecture of CodeWeaver Alpha 6 makes it simple to add support for new providers. Whether you have a proprietary internal embedding API or want to experiment with a new vector database, you can plug your implementation into CodeWeaver with just a few classes.
+The Dependency Injection (DI) architecture of CodeWeaver makes it simple to add support for new providers. Whether you have a proprietary internal embedding API or want to experiment with a new vector database, you can plug your implementation into CodeWeaver with just a few classes.
 
 ---
 
@@ -93,4 +93,4 @@ Raise a `ProviderError` if your API fails. CodeWeaver will catch this and automa
 
 ## Summary
 
-Custom providers turn CodeWeaver into a truly universal context platform. By following the DI-driven patterns of Alpha 6, you can ensure your integrations are as robust and resilient as the built-in providers.
+Custom providers turn CodeWeaver into a truly universal context platform. By following the DI-driven patterns, you can ensure your integrations are as robust and resilient as the built-in providers.

--- a/docs-site/src/content/docs/guides/installation.md
+++ b/docs-site/src/content/docs/guides/installation.md
@@ -4,7 +4,7 @@ title: "Installation and Setup"
 
 # Installation & Setup
 
-> **TL;DR:** This guide handles the initial installation and configuration of CodeWeaver Alpha 6. Use it to set up your environment and prepare your codebase for AI agent interaction. It saves time by providing a streamlined path from empty directory to "Exquisite Context."
+> **TL;DR:** This guide handles the initial installation and configuration of CodeWeaver. Use it to set up your environment and prepare your codebase for AI agent interaction. It saves time by providing a streamlined path from empty directory to "Exquisite Context."
 
 CodeWeaver transforms your codebase into a structured, semantic search engine for AI agents. This guide walks you through the 5-minute setup process to get CodeWeaver running on your machine.
 

--- a/docs-site/src/content/docs/guides/local-only.md
+++ b/docs-site/src/content/docs/guides/local-only.md
@@ -4,7 +4,7 @@ title: "Local-Only Operation"
 
 # Local-Only Operation
 
-> **TL;DR:** CodeWeaver Alpha 6 can run 100% locally with zero internet dependencies. Use it for airgapped environments or sensitive codebases where privacy is paramount. It saves your data from leaving your network while still providing high-quality semantic search.
+> **TL;DR:** CodeWeaver can run 100% locally with zero internet dependencies. Use it for airgapped environments or sensitive codebases where privacy is paramount. It saves your data from leaving your network while still providing high-quality semantic search.
 
 Many of our users work on proprietary or sensitive projects that cannot be shared with cloud-based AI providers. CodeWeaver is built with a **Privacy-First** architecture, allowing you to run all indexing, search, and storage locally on your own hardware.
 
@@ -61,4 +61,4 @@ Local-only operation doesn't mean slow search. CodeWeaver leverages specialized 
 
 ## Summary: Industrial-Grade Privacy
 
-CodeWeaver Alpha 6 ensures that privacy doesn't have to come at the cost of intelligence. By using its local-only mode, you can give your AI agents deep structural and semantic context without compromising your most sensitive data.
+CodeWeaver ensures that privacy doesn't have to come at the cost of intelligence. By using its local-only mode, you can give your AI agents deep structural and semantic context without compromising your most sensitive data.

--- a/docs-site/src/content/docs/guides/profiles.md
+++ b/docs-site/src/content/docs/guides/profiles.md
@@ -4,7 +4,7 @@ title: "Choosing a Profile"
 
 # Choosing a Profile
 
-> **TL;DR:** CodeWeaver Alpha 6 uses Profiles to simplify setup. Use `recommended` for production-grade search (Voyage AI) or `quickstart` for a free, local-only experience (FastEmbed). Profiles save you from manual configuration by bundling optimized provider settings.
+> **TL;DR:** CodeWeaver uses Profiles to simplify setup. Use `recommended` for production-grade search (Voyage AI) or `quickstart` for a free, local-only experience (FastEmbed). Profiles save you from manual configuration by bundling optimized provider settings.
 
 CodeWeaver offers three primary profiles to meet different cost, performance, and privacy requirements. You can select a profile during initialization with `cw init --profile <name>`.
 

--- a/docs-site/src/content/docs/guides/resilience.md
+++ b/docs-site/src/content/docs/guides/resilience.md
@@ -6,7 +6,7 @@ title: "Resilience: The Safety Net"
 
 > **TL;DR:** This module handles Resilient Intelligence. Use it to ensure your agents never lose context, even when cloud APIs fail. It saves your workflow by automatically switching to local providers (FastEmbed/Sentence-Transformers) during outages.
 
-CodeWeaver Alpha 6 includes an industrial-grade "Safety Net" that protects your AI agents from cloud provider failures. Whether it's an API timeout, a rate limit, or a total service outage, CodeWeaver keeps your context pipeline flowing.
+CodeWeaver includes an industrial-grade "Safety Net" that protects your AI agents from cloud provider failures. Whether it's an API timeout, a rate limit, or a total service outage, CodeWeaver keeps your context pipeline flowing.
 
 ---
 

--- a/docs-site/src/plugins/remark-version.ts
+++ b/docs-site/src/plugins/remark-version.ts
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 Knitli Inc.
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+/**
+ * Remark plugin that replaces {{VERSION}} tokens in markdown content
+ * with the current version derived from `git describe`.
+ *
+ * Runs at build time — no runtime cost.
+ */
+
+import { execFileSync } from "node:child_process";
+import { visit } from "unist-util-visit";
+import type { Root, Text } from "mdast";
+
+let cachedVersion: string | undefined;
+
+function getVersion(): string {
+  if (cachedVersion !== undefined) return cachedVersion;
+
+  try {
+    const raw = execFileSync("git", ["describe", "--tags", "--always"], {
+      encoding: "utf-8",
+      timeout: 5000,
+    }).trim();
+
+    // Convert git describe output to clean version:
+    //   v0.2.0                        -> 0.2.0
+    //   v0.2.0-3-gabcdef              -> 0.2.0-dev
+    //   v0.1.0-alpha.5-103-gabcdef    -> 0.1.0-dev
+    //   v0.2.0-beta.1                 -> 0.2.0-beta.1
+    const match = raw.match(/^v?(\d+\.\d+\.\d+)(?:-[a-z]+\.\d+)?(?:-(\d+)-g[a-f0-9]+)?$/);
+    if (match) {
+      const baseVersion = match[1];
+      const commitDistance = match[2];
+      cachedVersion = commitDistance ? `${baseVersion}-dev` : baseVersion;
+    } else {
+      cachedVersion = raw.replace(/^v/, "");
+    }
+  } catch {
+    cachedVersion = "0.0.0-unknown";
+  }
+
+  return cachedVersion;
+}
+
+export function remarkVersion(): (tree: Root) => void {
+  return (tree: Root) => {
+    const version = getVersion();
+
+    visit(tree, "text", (node: Text) => {
+      if (node.value.includes("{{VERSION}}")) {
+        node.value = node.value.replaceAll("{{VERSION}}", version);
+      }
+    });
+  };
+}

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -7,13 +7,12 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 
 # Release Checklist
 
-## Alpha Release (v0.1.0-alpha.1)
+## Minor Release (e.g., v0.2.0)
 
 ### Pre-Release Preparation
 
 - [ ] **Review README.md**
   - [ ] Installation instructions are current
-  - [ ] Alpha status is clearly communicated
   - [ ] Known limitations are documented
   - [ ] API key requirements are listed
 
@@ -41,43 +40,42 @@ SPDX-License-Identifier: MIT OR Apache-2.0
   ```bash
   # Commit all changes
   git add -A
-  git commit -m "chore: prepare for v0.1.0-alpha.1 release"
-  
-  # Create alpha tag
-  git tag v0.1.0-alpha.1
-  
+  git commit -m "chore: prepare for v0.2.0 release"
+
+  # Create version tag
+  git tag v0.2.0
+
   # Verify version
   uv build
-  ls -la dist/  # Should show: codeweaver.server.mcp-0.1.0a1-py3-none-any.whl
+  ls -la dist/  # Should show: code_weaver-0.2.0-py3-none-any.whl
   ```
 
 - [ ] **Push Release**
   ```bash
   # Push commit
   git push origin HEAD
-  
+
   # Push tag (triggers GitHub Actions)
-  git push origin v0.1.0-alpha.1
+  git push origin v0.2.0
   ```
 
 - [ ] **Verify Build**
   - [ ] GitHub Actions workflow completes successfully
   - [ ] Tests pass on all Python versions (3.12, 3.13, 3.14)
   - [ ] Package builds without errors
-  - [ ] GitHub release created and marked as "pre-release"
+  - [ ] GitHub release created
 
 - [ ] **Verify PyPI Upload**
-  - [ ] Package appears on PyPI: https://pypi.org/project/codeweaver/
-  - [ ] Version shows as `0.1.0a1`
+  - [ ] Package appears on PyPI: https://pypi.org/project/code-weaver/
+  - [ ] Version shows correctly
   - [ ] README renders correctly on PyPI
-  - [ ] Installation works: `pip install --pre codeweaver`
+  - [ ] Installation works: `pip install code-weaver`
 
 ### Post-Release
 
 - [ ] **Announcement**
   - [ ] Update project status in README (if needed)
   - [ ] Announce on relevant channels
-  - [ ] Set expectations: "Alpha - feature complete but not heavily tested"
 
 - [ ] **Monitoring**
   - [ ] Watch for GitHub issues
@@ -89,21 +87,10 @@ SPDX-License-Identifier: MIT OR Apache-2.0
   - [ ] Create issue template for feature requests
   - [ ] Document known issues in GitHub
 
-## Beta Release (v0.1.0-beta.1)
+## Stable Release (v1.0.0)
 
 ### Prerequisites
-- [ ] Alpha testing phase complete (2-4 weeks recommended)
-- [ ] Critical bugs from alpha addressed
-- [ ] Documentation updated based on alpha feedback
-- [ ] Core functionality validated by early testers
-
-### Process
-Follow same steps as alpha, but use `v0.1.0-beta.1` tag.
-
-## Stable Release (v0.1.0)
-
-### Prerequisites
-- [ ] Beta testing phase complete
+- [ ] All 0.x development milestones complete
 - [ ] All critical bugs resolved
 - [ ] Documentation comprehensive and accurate
 - [ ] Breaking changes documented
@@ -114,18 +101,17 @@ Follow same steps as alpha, but use `v0.1.0-beta.1` tag.
 ### Additional Steps
 - [ ] Create CHANGELOG.md if not exists
 - [ ] Update version references in docs
-- [ ] Remove "alpha/beta" warnings from README
 - [ ] Announce stable release
 
 ## Version Progression
 
 ```
-v0.1.0-alpha.1    → Alpha testing, gather feedback
-v0.1.0-alpha.2    → Bug fixes from alpha.1
-v0.1.0-beta.1     → Feature complete, wider testing
-v0.1.0-beta.2     → Bug fixes from beta.1
-v0.1.0-rc.1       → Release candidate, final validation
-v0.1.0            → Stable release
+v0.1.0            → Initial public release
+v0.1.1            → Patch fixes
+v0.2.0            → Monorepo split, extensibility
+v0.3.0            → Context Agent, pipeline orchestration
+v0.4.0            → Cloud orchestration, distributed indexing
+v1.0.0            → Stable release, API guarantees
 ```
 
 ## Rollback Procedure
@@ -141,13 +127,11 @@ If critical issues are discovered after release:
 2. **Create GitHub issue** documenting the problem
 
 3. **Fix the issue** and release new version
-   - For alpha: increment to `alpha.2`
-   - For beta: increment to `beta.2`
-   - For stable: create patch release `v0.1.1`
+   - For minor: create patch release (e.g., `v0.2.1`)
+   - For stable: create patch release (e.g., `v1.0.1`)
 
 ## Notes
 
-- **PyPI version normalization**: Git tag `v0.1.0-alpha.1` becomes `0.1.0a1` on PyPI (this is correct per PEP 440)
-- **Pre-release visibility**: Users must use `--pre` flag to install alpha/beta versions
 - **Version immutability**: Once published to PyPI, a version cannot be re-uploaded (must increment)
-- **Tag naming**: Always prefix with `v` (e.g., `v0.1.0-alpha.1` not `0.1.0-alpha.1`)
+- **Tag naming**: Always prefix with `v` (e.g., `v0.2.0` not `0.2.0`)
+- **SemVer 0.x**: Under `0.x.y`, minor version bumps may include breaking changes per SemVer convention

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -23,19 +23,6 @@ git push origin v0.1.0
 
 The build will create packages with version `0.1.0` (clean semantic version).
 
-### Alpha Release (Early Testing)
-**Format**: `X.Y.Z-alpha.N`
-**Example**: `0.1.0-alpha.1`
-**PyPI Format**: `0.1.0a1` (normalized per PEP 440)
-
-For early alpha releases:
-```bash
-git tag v0.1.0-alpha.1
-git push origin v0.1.0-alpha.1
-```
-
-The build will create packages with version `0.1.0a1` (Python normalizes `-alpha.1` to `a1`).
-
 ### Beta Release (Feature Complete)
 **Format**: `X.Y.Z-beta.N`
 **Example**: `0.1.0-beta.1`
@@ -73,19 +60,6 @@ Building with uncommitted changes appends `.dirty` suffix.
 1. Work on features on feature branches
 2. Each commit gets unique pre-release version
 3. Build creates: `codeweaver.server.mcp-0.1.0rc298+g2080710-py3-none-any.whl`
-
-### Alpha Release Workflow
-1. Commit and push changes to your branch
-2. Create alpha tag:
-   ```bash
-   git tag v0.1.0-alpha.1
-   git push origin v0.1.0-alpha.1
-   ```
-3. GitHub Actions automatically:
-   - Runs tests on Python 3.12, 3.13, 3.14
-   - Builds package with version `0.1.0a1`
-   - Publishes to PyPI (users must explicitly opt-in to pre-releases)
-   - Creates GitHub release marked as "pre-release"
 
 ### Production Release Workflow
 1. Merge to main branch
@@ -171,17 +145,12 @@ git push origin v0.1.1
 ## Best Practices
 
 1. **Use semantic versioning**: Major.Minor.Patch (e.g., 1.2.3)
-2. **Tag on main branch**: Only create release tags after merging to main (alpha/beta can be on feature branches)
+2. **Tag on main branch**: Only create release tags after merging to main (beta/rc can be on feature branches)
 3. **Clean working directory**: Commit all changes before tagging
 4. **Test on TestPyPI first**: Use TestPyPI workflow to validate before production
 5. **Document changes**: Update CHANGELOG.md before tagging
 
 ### Pre-Release Strategy
-
-**Alpha** (`-alpha.N`): Robust infrastructure, not heavily tested
-- Signals "feature-complete but not battle-tested"
-- Sets appropriate expectations for early testers
-- Users must explicitly install: `pip install --pre code-weaver`
 
 **Beta** (`-beta.N`): Feature complete, undergoing testing
 - Signals "mostly stable, finding edge cases"
@@ -195,14 +164,11 @@ git push origin v0.1.1
 
 ### Installing Pre-Releases
 
-Users who want to test alpha/beta versions must explicitly opt-in:
+Users who want to test beta/rc versions must explicitly opt-in:
 
 ```bash
-# Install latest pre-release (alpha, beta, or rc)
+# Install latest pre-release (beta or rc)
 pip install --pre code-weaver
-
-# Install specific alpha version
-pip install code-weaver==0.1.0a1
 
 # Upgrade to latest pre-release
 pip install --pre --upgrade code-weaver

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ keywords = [
   "voyageai",
 ]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 4 - Beta",
   "Environment :: Console",
   "Intended Audience :: Developers",
   "Intended Audience :: Information Technology",

--- a/scripts/testing/measure_context_reduction.py
+++ b/scripts/testing/measure_context_reduction.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2026 Knitli Inc.
 # SPDX-License-Identifier: MIT OR Apache-2.0
 """
-Context Reduction Measurement Script for CodeWeaver Alpha 6.
+Context Reduction Measurement Script for CodeWeaver.
 
 This script measures the "Exquisite Context" claim (60-80% context reduction) by:
 1. Calculating the 'Naive' baseline (all source files for a given language/query).
@@ -68,7 +68,7 @@ async def calculate_naive_baseline(project_path: Path, languages: Sequence[str])
 
 async def measure_reduction():
     print("=" * 70)
-    print("CodeWeaver Alpha 6: Context Reduction Benchmark")
+    print("CodeWeaver: Context Reduction Benchmark")
     print("=" * 70)
 
     # Initialize DI

--- a/src/codeweaver/cli/commands/init.py
+++ b/src/codeweaver/cli/commands/init.py
@@ -1006,7 +1006,7 @@ def init(
             "You can use CodeWeaver to search your codebase outside of an MCP client with [dim]codeweaver search[/dim]",
             "Check status with [dim]cw status[/dim]",
             "To check your config setup, run [dim]codeweaver doctor[/dim]",
-            "[red]CodeWeaver is in Alpha. There are bugs.[/red] Help us by reporting them: https://github.com/knitli/codeweaver/issues",
+            "[red]CodeWeaver is pre-1.0. There are bugs.[/red] Help us by reporting them: https://github.com/knitli/codeweaver/issues",
         ],
         title="Tips for Best Experience:",
     )

--- a/src/codeweaver/core/exceptions.py
+++ b/src/codeweaver/core/exceptions.py
@@ -60,14 +60,14 @@ def _get_issue_information() -> tuple[str, ...]:
 
     if _is_tty():
         return (
-            "[dark orange]CodeWeaver[/dark orange] [bold magenta]is in alpha[/bold magenta]. Please report possible bugs at https://github.com/knitli/codeweaver/issues",
+            "[dark orange]CodeWeaver[/dark orange] [bold magenta]is pre-1.0[/bold magenta]. Please report possible bugs at https://github.com/knitli/codeweaver/issues",
             "",
             "If you're not sure something is a bug, you can open a discussion at: https://github.com/knitli/codeweaver/discussions",
             "",
             "[bold]Thank you for helping us improve CodeWeaver! ❤️[/bold]",
         )
     return (
-        "CodeWeaver is in alpha. Please report possible bugs at https://github.com/knitli/codeweaver/issues",
+        "CodeWeaver is pre-1.0. Please report possible bugs at https://github.com/knitli/codeweaver/issues",
         "",
         "If you're not sure something is a bug, you can open a discussion at: https://github.com/knitli/codeweaver/discussions",
         "",

--- a/src/codeweaver/providers/env_registry/registry.py
+++ b/src/codeweaver/providers/env_registry/registry.py
@@ -52,7 +52,7 @@ class ProviderEnvRegistry:
         """Register provider configuration.
 
         Note: External registration is an internal API and may change.
-        CodeWeaver has no stable public API during alpha phase.
+        CodeWeaver has no stable public API during 0.x development.
 
         Args:
             provider: Provider name (lowercase)


### PR DESCRIPTION
This pull request updates the documentation and project metadata to reflect CodeWeaver's transition from "Alpha" status to a more stable, pre-1.0 "early release" phase. The changes focus on removing outdated alpha-specific language, updating versioning and roadmap details, and improving clarity for users and contributors. No core functionality is changed; all modifications are to documentation, badges, and descriptive text.

**Key changes include:**

### Project Status and Versioning Updates
- Updated all references from "Alpha" (e.g., "Alpha 6", "Alpha Release") to "early release", "0.x", or "pre-1.0" across documentation, README, and project overview files to reflect the current maturity and roadmap. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16-R22) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L38-R38) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L52-R60) [[4]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L22-R27) [[5]](diffhunk://#diff-06f0a9d19e41c8967a9cef68697194bf6d8c72c0b361f96c552e79938a667619L23-R23) [[6]](diffhunk://#diff-f6ed156e4bf5c791680662464b94ea5d753f219ee816b385f67870e2c0d7d4c7L10-R12) F4e03043L4R4, [[7]](diffhunk://#diff-cef2453133ac7af73fe3fe1c9ebfe43f7f6c68c2ec2ea309c94bc72c1c7c148eL11-R11) [[8]](diffhunk://#diff-cef2453133ac7af73fe3fe1c9ebfe43f7f6c68c2ec2ea309c94bc72c1c7c148eL111-R111) [[9]](diffhunk://#diff-1f7293df922532c62a2c073d6fc522dbda0619ba5463fe484d679c11e8ddc1ecL9-R9) [[10]](diffhunk://#diff-c084421a6b2243f05b0ab17ff1d7f96dedad37bc6ac18a956af3ee01c695615eL7-R7) [[11]](diffhunk://#diff-8a32cdd0a9bc7010bebb4510e2bc89966fabc8e1bf121b276f03566634e426fdL9-R9) [[12]](diffhunk://#diff-8a32cdd0a9bc7010bebb4510e2bc89966fabc8e1bf121b276f03566634e426fdL96-R96) [[13]](diffhunk://#diff-29ad9a7a1b1783d0e6077d78539ac1450f3b2d6502025bf1302320c392a45adfL7-R7) [[14]](diffhunk://#diff-29ad9a7a1b1783d0e6077d78539ac1450f3b2d6502025bf1302320c392a45adfL41-R41)

- Changed release badge in `README.md` to dynamically display the current PyPI version instead of a static "alpha" label.

### Roadmap and Release Planning
- Overhauled the roadmap documentation: replaced "Alpha 6/7/8/9" milestones with semantic versioning (0.1.x, 0.2.0, 0.3.0, etc.), clarified the project's next steps, and outlined the path to 1.0. [[1]](diffhunk://#diff-498feffd22333325900bc63e4ef5a4b70fefdf13a7ddbbce1a2f0483686581d6L2-R29) [[2]](diffhunk://#diff-498feffd22333325900bc63e4ef5a4b70fefdf13a7ddbbce1a2f0483686581d6L38-R51) [[3]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L450-R456) [[4]](diffhunk://#diff-55a2f3367a994f39514f00497195a66610c0b3fa2625bae4c7b7701d071c0c12L1153-R1153)

### Documentation Structure and Clarity
- Renamed and updated documentation pages and navigation to remove alpha-specific titles (e.g., "Roadmap to Alpha 7" → "Roadmap", "CLI Reference (Alpha 6)" → "CLI Reference"). [[1]](diffhunk://#diff-498feffd22333325900bc63e4ef5a4b70fefdf13a7ddbbce1a2f0483686581d6L2-R29) F4e03043L4R4, [[2]](diffhunk://#diff-6fe4f05e1e6e5844af99b5cc15fee10b67148c94634a0b7c2c83076aec0af45eL54-R56)
- Updated feature matrices, quick references, and TL;DR sections to remove alpha language and reflect the current stable foundation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L52-R60) [[2]](diffhunk://#diff-c084421a6b2243f05b0ab17ff1d7f96dedad37bc6ac18a956af3ee01c695615eL7-R7) [[3]](diffhunk://#diff-1f7293df922532c62a2c073d6fc522dbda0619ba5463fe484d679c11e8ddc1ecL9-R9) [[4]](diffhunk://#diff-29ad9a7a1b1783d0e6077d78539ac1450f3b2d6502025bf1302320c392a45adfL7-R7) [[5]](diffhunk://#diff-8a32cdd0a9bc7010bebb4510e2bc89966fabc8e1bf121b276f03566634e426fdL9-R9)

### Minor Code and Config Improvements
- Improved Astro docs site configuration to support version substitution in markdown via a new `remark-version` plugin and updated navigation labels. [[1]](diffhunk://#diff-6fe4f05e1e6e5844af99b5cc15fee10b67148c94634a0b7c2c83076aec0af45eR6-R9) [[2]](diffhunk://#diff-6fe4f05e1e6e5844af99b5cc15fee10b67148c94634a0b7c2c83076aec0af45eL54-R56) [[3]](diffhunk://#diff-6fe4f05e1e6e5844af99b5cc15fee10b67148c94634a0b7c2c83076aec0af45eL81-R92)

### Minor Fixes
- Fixed a variable naming typo in a progress tracking markdown file.

## Summary by Sourcery

Update documentation, metadata, and tooling to reflect CodeWeaver’s transition from alpha to a pre-1.0 early release with a 0.x semantic versioning roadmap.

Enhancements:
- Update PyPI classifiers and various user-facing strings to describe the project as pre-1.0 rather than alpha, aligning status messaging across the codebase.
- Add a remark plugin to the docs site to inject the current version into markdown at build time and wire it into the Astro configuration.
- Change the README release badge to display the current PyPI version dynamically instead of a static alpha label.

Documentation:
- Refresh README, guides, and concepts docs to remove alpha-specific language and describe CodeWeaver as a 0.x early release with a stable DI-based foundation.
- Revise roadmap, release checklist, and versioning strategy docs to use 0.x/1.0 semantic milestones instead of alpha/beta phases, clarifying the path to 1.0.
- Adjust security and agent guidance documentation to reflect pre-1.0 status and updated project expectations.

Tests:
- Tidy test and example code snippets in documentation and progress reports without changing behavior.

Chores:
- Fix minor formatting issues, whitespace, and wording in markdown, scripts, and comments to improve consistency and readability.