### PR TITLE
fix: handle UNSET sentinel correctly in ProviderSettings initialization

### DIFF
--- a/src/codeweaver/providers/config/root_settings.py
+++ b/src/codeweaver/providers/config/root_settings.py
@@ -140,10 +140,13 @@ class CodeWeaverProviderSettings(CodeWeaverCoreSettings):
                 )
             )
         else:
+            effective_profile = (
+                profile_config
+                if profile_config is not UNSET and profile_config
+                else ProviderProfile.RECOMMENDED
+            )
             provider = ProviderSettings.model_construct(
-                **(
-                    cast(ProviderProfile, profile_config or ProviderProfile.RECOMMENDED)
-                ).as_provider_settings()
+                **cast(ProviderProfile, effective_profile).as_provider_settings()
             )
         self.provider = provider
         await super()._initialize(**kwargs)


### PR DESCRIPTION
## Summary

Fixed critical bug where all CLI commands crashed with `AttributeError: 'Unset' object has no attribute 'as_provider_settings'`.

## Root Cause

The `UNSET` sentinel is a truthy object, so `profile_config or ProviderProfile.RECOMMENDED` doesn't short-circuit when `profile_config` is `UNSET`. This caused the code to attempt calling `UNSET.as_provider_settings()`, which raises `AttributeError`.

## Fix

Changed to use explicit identity check `profile_config is not UNSET` before fallback, matching the pattern already used elsewhere in the same file (lines 106-117, 126-131).

## Testing

✅ `cw --help` now displays help text correctly
✅ `cw doctor --help` now displays help text correctly
✅ Exit code is 0 (success)
✅ Code quality checks pass

Fixes #300

---

Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Bug Fixes:
- Prevent CLI commands from crashing with an AttributeError when provider profile configuration is UNSET by explicitly falling back to the recommended profile.