### PR TITLE
fix(providers): guard EmbedByTypeResponse import with TYPE_CHECKING

### DIFF
--- a/src/codeweaver/providers/embedding/providers/cohere.py
+++ b/src/codeweaver/providers/embedding/providers/cohere.py
@@ -9,9 +9,12 @@ from __future__ import annotations
 import asyncio
 
 from collections.abc import Sequence
-from typing import Any, ClassVar, Literal, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
 
-from cohere import EmbedByTypeResponse
+
+if TYPE_CHECKING:
+    from cohere import EmbedByTypeResponse
+
 from pydantic import SkipValidation
 
 from codeweaver.core import CodeChunk, ConfigurationError, Provider


### PR DESCRIPTION
## Summary

This PR fixes a latent bug where `EmbedByTypeResponse` was imported at the top level of `src/codeweaver/providers/embedding/providers/cohere.py`, causing the module to crash on bare installs without the `cohere` package.

## Changes

- Moved `from cohere import EmbedByTypeResponse` to a `TYPE_CHECKING` block
- Added `TYPE_CHECKING` to typing imports

The import is only used for type annotations (line 127) and the file already has `from __future__ import annotations`, making this change safe.

## Pattern Alignment

This fix follows the established pattern used throughout the provider modules:
- `clients/multi.py:46-49`
- `clients/agent.py:41-44`

## Testing

✅ Ruff check: Passed
✅ Type check (ty): Passed

Fixes #304

---
Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Bug Fixes:
- Prevent Cohere embedding provider module from failing to import on installations that lack the cohere dependency.