### PR TITLE
⚡ Bolt: Optimize repeated strip calls with walrus operator

### DIFF
--- a/src/codeweaver/providers/optimize.py
+++ b/src/codeweaver/providers/optimize.py
@@ -51,7 +51,9 @@ def _nvidia_smi_device_ids() -> list[int]:
             text=True,
             timeout=2.0,
         )
-        return [int(line.strip()) for line in out.splitlines() if line.strip().isdigit()]
+        # Optimization: Use walrus operator to avoid calling .strip() twice per line
+        # Expected Impact: Minor reduction in redundant string allocations and operations
+        return [int(stripped) for line in out.splitlines() if (stripped := line.strip()).isdigit()]
     return []
 
 


### PR DESCRIPTION
💡 **What:** Modified `_nvidia_smi_device_ids` in `src/codeweaver/providers/optimize.py` to use the Python walrus operator (`:=`) inside its list comprehension.
🎯 **Why:** The previous implementation called `line.strip()` twice per string iteration: once to check `.isdigit()` and again before passing to `int()`.
📊 **Impact:** Minor reduction in redundant string allocations and string operations when checking lines emitted by `nvidia-smi`.
🔬 **Measurement:** Verify by running tests or `nvidia-smi` parser logic to ensure correctness. The underlying change reduces string evaluation by exactly 1 call per parsed iteration.

---
*PR created automatically by Jules for task [6689209347987616311](https://jules.google.com/task/6689209347987616311) started by @bashandbone*

## Summary by Sourcery

Enhancements:
- Use the walrus operator in the NVIDIA SMI device ID parser to eliminate duplicate strip calls per line.