### PR TITLE
⚡ Bolt: [performance improvement] Use walrus operator in optimize.py

### DIFF
--- a/src/codeweaver/providers/optimize.py
+++ b/src/codeweaver/providers/optimize.py
@@ -51,7 +51,8 @@ def _nvidia_smi_device_ids() -> list[int]:
             text=True,
             timeout=2.0,
         )
-        return [int(line.strip()) for line in out.splitlines() if line.strip().isdigit()]
+        # Use walrus operator to prevent redundant `.strip()` string manipulations and allocations
+        return [int(stripped) for line in out.splitlines() if (stripped := line.strip()).isdigit()]
     return []
 
 


### PR DESCRIPTION
💡 What: Implemented the walrus operator inside a list comprehension in `src/codeweaver/providers/optimize.py`'s `_nvidia_smi_device_ids` function.
🎯 Why: To prevent evaluating `.strip()` twice per iteration over the `nvidia-smi` output lines (once in the condition, once in the int cast), which causes redundant method execution and memory allocation.
📊 Impact: Minor CPU time and memory allocation savings due to executing the string manipulation once instead of twice.
🔬 Measurement: Run standard `pytest` over the `providers` module to ensure it still correctly parses comma-separated ints out of `nvidia-smi` output logic.

---
*PR created automatically by Jules for task [3881520017440252450](https://jules.google.com/task/3881520017440252450) started by @bashandbone*

## Summary by Sourcery

Enhancements:
- Simplify and optimize _nvidia_smi_device_ids by reusing stripped line values instead of recomputing them in the list comprehension.