### PR TITLE
⚡ Bolt: [performance improvement] optimize redundant strip

### DIFF
--- a/src/codeweaver/providers/optimize.py
+++ b/src/codeweaver/providers/optimize.py
@@ -51,7 +51,8 @@ def _nvidia_smi_device_ids() -> list[int]:
             text=True,
             timeout=2.0,
         )
-        return [int(line.strip()) for line in out.splitlines() if line.strip().isdigit()]
+        # Using walrus operator avoids redundant .strip() calls on each line
+        return [int(stripped) for line in out.splitlines() if (stripped := line.strip()).isdigit()]
     return []
 
 


### PR DESCRIPTION
💡 What: Used the walrus operator (`:=`) inside `_nvidia_smi_device_ids` in `src/codeweaver/providers/optimize.py` to prevent redundant `.strip()` string manipulations.
🎯 Why: `.strip()` was being evaluated twice per line inside a generator comprehension within `_nvidia_smi_device_ids()`, causing unnecessary allocation and duplicate string operations on each iteration.
📊 Impact: Reduces string allocation and `.strip()` evaluation overhead by half within the context of checking NVIDIA GPU availability.
🔬 Measurement: Verified that `uv run pytest tests/unit/providers/ --no-cov` passes without regressions, meaning output logic matches pre-walrus state exactly.

---
*PR created automatically by Jules for task [13165653728050944631](https://jules.google.com/task/13165653728050944631) started by @bashandbone*

## Summary by Sourcery

Enhancements:
- Reduce repeated .strip() calls when parsing nvidia-smi output in _nvidia_smi_device_ids to lower string allocation overhead.