### PR TITLE
⚡ Bolt: Use pre-computed tuples for static iterations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -25,3 +25,7 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 ## 2025-04-12 - Walrus Operator Optimization
 **Learning:** Using the walrus operator inside a list comprehension to avoid redundant execution of string methods (like `.strip()`) is an effective and safe micro-optimization. The result of the assignment inside the list comprehension will intentionally leak into the scope of the caller function, but this standard Python behavior does not cause naming conflicts in non-recursive or non-global scopes.
 **Action:** Always favor using the walrus operator `:=` in list comprehensions or conditionals when identical string manipulations (e.g., `.strip()`) or expensive evaluation calls appear repeatedly within the identical expression branch.
+
+## 2026-04-14 - Pre-computing Bound Method Collections in Hot Loops
+**Learning:** Constructing a collection of bound methods (e.g., `[self.method_a, self.method_b]`) inside a frequently called function incurs dual overhead: the allocation of the collection itself (like a list or tuple) and the creation of new bound method objects on every execution. This can negatively impact performance in tight loops or classification engines.
+**Action:** When a static collection of instance methods needs to be repeatedly iterated over, pre-compute and store it as a tuple attribute during the class's `__init__` (e.g., `self._methods = (self.a, self.b)`). This avoids both allocation overhead and repeated bound method creation.

--- a/src/codeweaver/semantic/classifier.py
+++ b/src/codeweaver/semantic/classifier.py
@@ -360,6 +360,17 @@ class GrammarBasedClassifier:
         """Initialize grammar-based classifier."""
         # Build Category name → SemanticClass mapping
         self._classification_map = self._build_category_to_semantic_map
+        # Pre-compute classification methods tuple for iteration performance optimization
+        # ⚡ Bolt: Use a pre-computed tuple literal to avoid list allocation overhead in hot loop
+        self._classification_methods = (
+            self._classify_known_exceptions,
+            self._classify_by_can_be_anywhere,
+            self._classify_from_token_purpose,
+            self._classify_multi_tier_things,
+            self._classify_from_category,
+            self._classify_from_direct_connections,
+            self._classify_by_cross_language_lookup,
+        )
 
     def _classify_by_can_be_anywhere(
         self, thing: CompositeThing | Token, language: SemanticSearchLanguage
@@ -844,15 +855,7 @@ class GrammarBasedClassifier:
                 adjustment=100,
             )
         results: list[GrammarClassificationResult] = []
-        for method in [
-            self._classify_known_exceptions,
-            self._classify_by_can_be_anywhere,
-            self._classify_from_token_purpose,
-            self._classify_multi_tier_things,
-            self._classify_from_category,
-            self._classify_from_direct_connections,
-            self._classify_by_cross_language_lookup,
-        ]:
+        for method in self._classification_methods:
             if classification := method(thing, language):
                 # Check if it's a tuple but NOT a GrammarClassificationResult (which is a NamedTuple, hence a tuple)
                 if not isinstance(classification, GrammarClassificationResult):


### PR DESCRIPTION
💡 **What**: Pre-computed the `self._classification_methods` tuple of classification methods within the `__init__` constructor instead of creating an inline list structure every time the `classify` loop was executed.
🎯 **Why**: When a static collection of instance methods needs to be repeatedly iterated over, constructing the collection over and over incurs double overhead: the allocation of the list memory and the creation of the bound instance method objects themselves. 
📊 **Impact**: Reduces object creation time and decreases list allocation processing within the AST-based Node classification hotloop, improving raw iteration evaluation speeds.
🔬 **Measurement**: Verified using targeted tests (`mise //:test tests/unit/engine/chunker/`) to ensure no regressions during classifications.

---
*PR created automatically by Jules for task [2745804533802310033](https://jules.google.com/task/2745804533802310033) started by @bashandbone*

## Summary by Sourcery

Pre-compute and reuse the classifier’s bound method collection to reduce allocation overhead in the classification hot loop and document this optimization pattern in the Bolt guidelines.

Enhancements:
- Pre-compute the tuple of classification methods in the classifier initializer and reuse it during thing classification to avoid per-call list construction and bound method creation.

Documentation:
- Add a Bolt guideline documenting the performance benefits of pre-computing bound method collections for hot loops.