### PR TITLE
⚡ Bolt: Optimize _nvidia_smi_device_ids string allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -25,3 +25,6 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 ## 2025-04-12 - Walrus Operator Optimization
 **Learning:** Using the walrus operator inside a list comprehension to avoid redundant execution of string methods (like `.strip()`) is an effective and safe micro-optimization. The result of the assignment inside the list comprehension will intentionally leak into the scope of the caller function, but this standard Python behavior does not cause naming conflicts in non-recursive or non-global scopes.
 **Action:** Always favor using the walrus operator `:=` in list comprehensions or conditionals when identical string manipulations (e.g., `.strip()`) or expensive evaluation calls appear repeatedly within the identical expression branch.
+## 2025-05-08 - String Optimization
+**Learning:** Redundant evaluations of `.strip()` in list comprehensions and generators cause unnecessary allocation and processing. Since Python 3.8, the walrus operator (`:=`) allows the evaluation of variables inline, preventing duplicate processing overhead.
+**Action:** Use the walrus operator (`:=`) to capture the result of string manipulation like `.strip()` in comprehensions if that exact modified string needs to be accessed again in the conditional or expression logic.

--- a/src/codeweaver/providers/optimize.py
+++ b/src/codeweaver/providers/optimize.py
@@ -51,7 +51,8 @@ def _nvidia_smi_device_ids() -> list[int]:
             text=True,
             timeout=2.0,
         )
-        return [int(line.strip()) for line in out.splitlines() if line.strip().isdigit()]
+        # ⚡ Bolt Optimization: Use walrus operator to prevent redundant line.strip() evaluation
+        return [int(stripped) for line in out.splitlines() if (stripped := line.strip()).isdigit()]
     return []
 
 


### PR DESCRIPTION
**💡 What**: Used the walrus operator (`:=`) inside a list comprehension to assign `stripped = line.strip()` instead of calling `.strip()` twice for each line of the output from `nvidia-smi`.
**🎯 Why**: Reduces redundant string processing and allocation overhead.
**📊 Impact**: Minor CPU cycle saving and lower memory footprint per evaluation.
**🔬 Measurement**: Test the code directly in unit tests and standard usage scenarios to verify exact array matches against original behavior.

---
*PR created automatically by Jules for task [3699686724478163224](https://jules.google.com/task/3699686724478163224) started by @bashandbone*

## Summary by Sourcery

Optimize NVIDIA SMI device ID parsing to avoid redundant string processing and document the string optimization pattern in the Bolt guidelines.

Enhancements:
- Reduce duplicate .strip() evaluations in _nvidia_smi_device_ids by capturing the stripped line once per iteration.
- Extend Bolt optimization guidelines with a new entry on using the walrus operator to avoid repeated string manipulations in comprehensions.