### PR TITLE
⚡ Bolt: Optimize duplicate .strip() calls with walrus operator

### DIFF
--- a/src/codeweaver/providers/optimize.py
+++ b/src/codeweaver/providers/optimize.py
@@ -51,7 +51,8 @@ def _nvidia_smi_device_ids() -> list[int]:
             text=True,
             timeout=2.0,
         )
-        return [int(line.strip()) for line in out.splitlines() if line.strip().isdigit()]
+        # Use walrus operator to prevent redundant evaluation of line.strip()
+        return [int(stripped) for line in out.splitlines() if (stripped := line.strip()).isdigit()]
     return []
 
 


### PR DESCRIPTION
💡 What: The optimization implements the walrus operator in a list comprehension inside `_nvidia_smi_device_ids` in `src/codeweaver/providers/optimize.py`.
🎯 Why: `line.strip()` was being evaluated twice for each line of output from `nvidia-smi`—once to check if it's a digit, and again to cast it to an integer. This eliminates the redundant evaluation.
📊 Impact: Reduces string operations and unnecessary evaluation overhead slightly when parsing GPU device IDs.
🔬 Measurement: Verified that tests pass and `uv run pytest tests/unit/providers` runs cleanly. The return behavior remains strictly identical.

---
*PR created automatically by Jules for task [9031185162862270831](https://jules.google.com/task/9031185162862270831) started by @bashandbone*

## Summary by Sourcery

Enhancements:
- Streamline _nvidia_smi_device_ids by reusing stripped line values instead of calling strip() multiple times per line.