### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Arbitrary Code Execution in Type Resolution Eval

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,8 @@
 **Vulnerability:** Found an unused `_attempt_import` function in `src/codeweaver/server/mcp/server.py` that dynamically imports a module directly from unvalidated configuration (`import_module(mw.rsplit(".", 1)[0])`), leading to potential arbitrary code execution.
 **Learning:** Functions that perform dynamic imports should not be left around in the codebase if they are unused, especially if they are designed to take unvalidated strings as input.
 **Prevention:** Avoid dynamic imports based on configuration or inputs without strict whitelisting. Use tools like `semgrep` with python security rules to actively catch these patterns.
+
+## 2026-04-21 - Arbitrary Code Execution in Type Resolution Eval
+**Vulnerability:** Found an arbitrary code execution vulnerability in `src/codeweaver/core/di/container.py` during type resolution. The AST validator `_safe_eval_type` permitted any `ast.Call` nodes to be executed through `eval()` within the provided `globalns` environment.
+**Learning:** AST whitelisting must strictly validate the identifier names being called. Validating the node type alone is insufficient to prevent evaluating functions injected via dynamic namespaces.
+**Prevention:** Explicitly whitelist permitted identifier names inside `ast.Call` validations to ensure that only expected dependency injection annotations (`Depends`, `depends`, `Field`, `PrivateAttr`) are instantiated.

--- a/src/codeweaver/core/di/container.py
+++ b/src/codeweaver/core/di/container.py
@@ -136,6 +136,14 @@ class Container[T]:
                 if isinstance(node, ast.Attribute) and node.attr.startswith("__"):
                     raise TypeError(f"Forbidden dunder attribute: {node.attr}")
 
+                # Restrict function calls to a safe whitelist to prevent arbitrary code execution
+                if isinstance(node, ast.Call):
+                    allowed_funcs = {"Depends", "depends", "Field", "PrivateAttr"}
+                    if not isinstance(node.func, ast.Name):
+                        raise TypeError(f"Forbidden call: function must be a simple name, got {type(node.func).__name__}")
+                    if node.func.id not in allowed_funcs:
+                        raise TypeError(f"Forbidden call: only {', '.join(allowed_funcs)} are allowed, got {node.func.id}")
+
                 super().generic_visit(node)
 
         try:


### PR DESCRIPTION
The `_safe_eval_type` method in `src/codeweaver/core/di/container.py` was found to have a severe Arbitrary Code Execution vulnerability. 

The AST pass allowed `ast.Call` nodes so that Pydantic fields or Dependency Injection annotations (e.g. `Depends()`) could be evaluated via `eval()`. Because `eval` is called with a `globalns` environment (which can contain local functions and imports), an attacker could execute arbitrary functions by supplying an unexpected type string (like `"ExploitClass().execute()"`).

## Fix
The `TypeValidator.generic_visit` method was updated:
- It now enforces a strict whitelist of known-safe functions that can be called during type evaluation (`Depends`, `depends`, `Field`, `PrivateAttr`).
- It enforces that `node.func` must be an `ast.Name` to prevent dot notation attacks (e.g. `os.system`).

Tests have been run, confirming the exploit is prevented, while DI container functions remain fully operational. Learnings have been documented in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [2303909245205650646](https://jules.google.com/task/2303909245205650646) started by @bashandbone*

## Summary by Sourcery

Harden type resolution evaluation in the DI container to prevent arbitrary code execution and document the related security incident in Sentinel notes.

Bug Fixes:
- Prevent arbitrary code execution during type resolution by restricting evaluated function calls to a small whitelist of safe dependency-related helpers.

Documentation:
- Add a Sentinel security incident entry describing the arbitrary code execution vulnerability in type resolution and the mitigation via strict AST call whitelisting.