### PR TITLE
🛡️ Sentinel: [CRITICAL] Secure dynamic imports in get_agent_model_capabilities

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,7 @@
 **Vulnerability:** Found an unused `_attempt_import` function in `src/codeweaver/server/mcp/server.py` that dynamically imports a module directly from unvalidated configuration (`import_module(mw.rsplit(".", 1)[0])`), leading to potential arbitrary code execution.
 **Learning:** Functions that perform dynamic imports should not be left around in the codebase if they are unused, especially if they are designed to take unvalidated strings as input.
 **Prevention:** Avoid dynamic imports based on configuration or inputs without strict whitelisting. Use tools like `semgrep` with python security rules to actively catch these patterns.
+## 2026-04-21 - Unvalidated dynamic import vulnerability removed
+**Vulnerability:** Found dynamic import logic (`importlib.import_module(f"pydantic_ai.profiles.{provider}")`) in `src/codeweaver/providers/agent/capabilities.py` that accepted potentially unvalidated `provider` strings from parsed inputs.
+**Learning:** Passing unvalidated inputs directly to `importlib.import_module` can lead to unintended execution paths or potential arbitrary code execution.
+**Prevention:** Always validate external or dynamically parsed inputs against a strict whitelist of expected/safe values before using them to import modules.

--- a/src/codeweaver/providers/agent/capabilities.py
+++ b/src/codeweaver/providers/agent/capabilities.py
@@ -44,6 +44,9 @@ def _parse_model_name(name: str) -> tuple[str, str]:
 
 
 def _attempt_to_get_profile(provider: str, full_name: str) -> AgentModelCapabilities | None:
+    # Security: Validate the provider against a known whitelist before using it in a dynamic import
+    if provider not in PYDANTIC_AI_MODEL_CAPABILITIES_PROVIDERS:
+        return None
     with contextlib.suppress(ImportError):
         module = importlib.import_module(f"pydantic_ai.profiles.{provider}")
         if profile_getter := getattr(module, f"{provider}_model_profile", None):
@@ -58,6 +61,9 @@ def get_agent_model_capabilities() -> dict[KnownAgentModelName, AgentModelCapabi
     profiles: dict[KnownAgentModelName, AgentModelCapabilities] = {}
     for name in model_names:
         provider, _model = _parse_model_name(name)
+        # Security: Validate the provider against a known whitelist before using it in a dynamic import
+        if provider not in PYDANTIC_AI_MODEL_CAPABILITIES_PROVIDERS:
+            continue
         try:
             profile = None
             module = importlib.import_module(f"pydantic_ai.profiles.{provider}")


### PR DESCRIPTION
Secures the dynamic module import (`importlib.import_module`) in `src/codeweaver/providers/agent/capabilities.py` by validating the `provider` string against a known whitelist (`PYDANTIC_AI_MODEL_CAPABILITIES_PROVIDERS`) before execution, thereby preventing arbitrary code execution. Also adds a journal entry to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [5255885415642014120](https://jules.google.com/task/5255885415642014120) started by @bashandbone*

## Summary by Sourcery

Validate agent capability provider names against a known whitelist before performing dynamic imports to harden security around model profile loading and document the change in the Sentinel security journal.

Bug Fixes:
- Prevent potential arbitrary code execution by rejecting untrusted provider strings before using them in importlib-based dynamic imports in agent capability resolution.

Documentation:
- Add a Sentinel journal entry describing the unvalidated dynamic import vulnerability in agent capabilities and its remediation via whitelist validation.