### PR TITLE
⚡ Bolt: Optimize linear lookups in file extension checks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -25,3 +25,6 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 ## 2025-04-12 - Walrus Operator Optimization
 **Learning:** Using the walrus operator inside a list comprehension to avoid redundant execution of string methods (like `.strip()`) is an effective and safe micro-optimization. The result of the assignment inside the list comprehension will intentionally leak into the scope of the caller function, but this standard Python behavior does not cause naming conflicts in non-recursive or non-global scopes.
 **Action:** Always favor using the walrus operator `:=` in list comprehensions or conditionals when identical string manipulations (e.g., `.strip()`) or expensive evaluation calls appear repeatedly within the identical expression branch.
+## 2026-04-14 - Replace Generator Expressions with For Loops in Linear Lookups
+**Learning:** In Python performance optimization, replacing a generator expression wrapped in `next()` (e.g., `next((x for x in iterable if condition), default)`) with a standard `for` loop that uses an early `return` can significantly speed up linear lookups by eliminating generator frame allocation overhead.
+**Action:** Replace `next((...))` generator patterns with explicit `for` loops and early returns in hot paths or linear lookups. Suppress linting rules like `SIM110` using `noqa` when necessary to maintain this optimization.

--- a/src/codeweaver/core/metadata.py
+++ b/src/codeweaver/core/metadata.py
@@ -247,7 +247,12 @@ class ExtLangPair(NamedTuple):
         """Check if the extension is a documentation file."""
         from codeweaver.core.file_extensions import DOC_FILES_EXTENSIONS
 
-        return next((True for doc_ext in DOC_FILES_EXTENSIONS if doc_ext.ext == self.ext), False)
+        # Performance: Replace generator expression with explicit loop and early return
+        # to eliminate generator frame allocation overhead during linear lookup.
+        for doc_ext in DOC_FILES_EXTENSIONS:  # noqa: SIM110
+            if doc_ext.ext == self.ext:
+                return True
+        return False
 
     @property
     def is_code(self) -> bool:
@@ -259,7 +264,12 @@ class ExtLangPair(NamedTuple):
         """Check if the extension is a data file."""
         from codeweaver.core.file_extensions import DATA_FILES_EXTENSIONS
 
-        return next((True for data_ext in DATA_FILES_EXTENSIONS if data_ext.ext == self.ext), False)
+        # Performance: Replace generator expression with explicit loop and early return
+        # to eliminate generator frame allocation overhead during linear lookup.
+        for data_ext in DATA_FILES_EXTENSIONS:  # noqa: SIM110
+            if data_ext.ext == self.ext:
+                return True
+        return False
 
     @property
     def as_source(self) -> ChunkSource:


### PR DESCRIPTION
💡 **What:** Optimized the `is_doc` and `is_data` property getters in `src/codeweaver/core/metadata.py` by replacing `next((...))` generator expressions with standard `for` loops that use early returns. Suppressed the `ruff` rule `SIM110` with `# noqa` to ensure the manual loop is preserved over an `any()` generator.

🎯 **Why:** In CPython, evaluating generator comprehensions inside functions like `next()` or `any()` involves allocating a generator object and evaluating its frames. When performing a simple linear search to find a matching extension, manually writing out a `for` loop that returns early avoids this overhead completely. These properties are accessed frequently during file discovery, making this a small but compounding speedup.

📊 **Impact:** Reduces evaluation overhead in file metadata extension lookups by entirely bypassing generator frame allocations, yielding faster linear lookups.

🔬 **Measurement:** The optimization can be verified by profiling calls to `FileMetadata.is_doc` and `FileMetadata.is_data` over a large list of files compared to their previous implementations, seeing a drop in generator allocation overhead.

---
*PR created automatically by Jules for task [7415917703769671111](https://jules.google.com/task/7415917703769671111) started by @bashandbone*

## Summary by Sourcery

Optimize file metadata extension classification checks and document the performance guideline in the optimization playbook.

Enhancements:
- Improve performance of documentation and data file extension checks by replacing generator-based lookups with explicit loops and early returns.

Documentation:
- Extend the Bolt optimization guide with a new rule recommending explicit for-loops over generator expressions in hot-path linear lookups.