### PR TITLE
🛡️ Sentinel: [CRITICAL] Restrict ast.Call in type string evaluation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,8 @@
 **Vulnerability:** Found an unused `_attempt_import` function in `src/codeweaver/server/mcp/server.py` that dynamically imports a module directly from unvalidated configuration (`import_module(mw.rsplit(".", 1)[0])`), leading to potential arbitrary code execution.
 **Learning:** Functions that perform dynamic imports should not be left around in the codebase if they are unused, especially if they are designed to take unvalidated strings as input.
 **Prevention:** Avoid dynamic imports based on configuration or inputs without strict whitelisting. Use tools like `semgrep` with python security rules to actively catch these patterns.
+
+## 2026-04-21 - Arbitrary code execution via ast.Call in type string evaluation
+**Vulnerability:** Found that `_safe_eval_type` in `src/codeweaver/core/di/container.py` used an AST validator that allowed `ast.Call` nodes to execute any available callable in the evaluation namespace. By crafting a type annotation string like `"os.system('echo pwned')"` (provided `os` is injected or imported), an attacker could achieve arbitrary code execution because the validated string was subsequently evaluated with `eval()`.
+**Learning:** Even when AST validation correctly rejects `__` dunder accesses and restricts allowed node types, allowing generic `ast.Call` nodes remains dangerous if the execution environment contains potent functions or objects. Whitelisting specific functions (like `Depends`) inside the `ast.Call` validator is required to prevent bypasses.
+**Prevention:** Explicitly restrict function calls (`ast.Call`) in custom `eval` AST validators to only known, safe operations. Ensure any code dynamically evaluating parsed input never permits generic execution.

--- a/src/codeweaver/core/di/container.py
+++ b/src/codeweaver/core/di/container.py
@@ -136,6 +136,12 @@ class Container[T]:
                 if isinstance(node, ast.Attribute) and node.attr.startswith("__"):
                     raise TypeError(f"Forbidden dunder attribute: {node.attr}")
 
+                # Security: Restrict calls to prevent arbitrary code execution during type evaluation
+                if isinstance(node, ast.Call) and (
+                    not isinstance(node.func, ast.Name) or node.func.id != "Depends"
+                ):
+                    raise TypeError("Forbidden call type: only Depends() is allowed")
+
                 super().generic_visit(node)
 
         try:


### PR DESCRIPTION
Fixed an Arbitrary Code Execution vulnerability in `_safe_eval_type` where generic `ast.Call` nodes were allowed to execute during dynamic type evaluation.

🚨 Severity: CRITICAL
💡 Vulnerability: The AST validation logic meant to ensure safety before running `eval()` on type strings allowed unrestricted `ast.Call` nodes. This could allow an attacker to execute arbitrary code (e.g., `os.system(...)`) via functions available in the evaluation context.
🎯 Impact: Arbitrary code execution when parsing malicious user-provided type strings or configuration.
🔧 Fix: Modified `TypeValidator` to strictly limit `ast.Call` instances to the safe `Depends` function.
✅ Verification: Ran unit tests and the AST validation is now strict.

---
*PR created automatically by Jules for task [9014954985282109260](https://jules.google.com/task/9014954985282109260) started by @bashandbone*

## Summary by Sourcery

Harden AST-based validation used in type string evaluation to prevent arbitrary code execution and document the newly discovered vulnerability and its mitigation.

Bug Fixes:
- Block all function calls in type string AST validation except for the explicitly allowed Depends() helper to close an arbitrary code execution vulnerability.

Documentation:
- Extend the Sentinel security log with details of the ast.Call-based arbitrary code execution vulnerability, lessons learned, and prevention guidance.