### PR TITLE
🛡️ Sentinel: [CRITICAL] Prevent Arbitrary Code Execution in DI Container Type Resolution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,8 @@
 **Vulnerability:** Found an unused `_attempt_import` function in `src/codeweaver/server/mcp/server.py` that dynamically imports a module directly from unvalidated configuration (`import_module(mw.rsplit(".", 1)[0])`), leading to potential arbitrary code execution.
 **Learning:** Functions that perform dynamic imports should not be left around in the codebase if they are unused, especially if they are designed to take unvalidated strings as input.
 **Prevention:** Avoid dynamic imports based on configuration or inputs without strict whitelisting. Use tools like `semgrep` with python security rules to actively catch these patterns.
+
+## 2026-04-21 - Restrict ast.Call in AST parsing for eval
+**Vulnerability:** Found a vulnerability in `_safe_eval_type` in `src/codeweaver/core/di/container.py` where allowing generic `ast.Call` nodes during AST validation before an `eval()` call could lead to Arbitrary Code Execution (ACE) if an attacker injects a malicious function call (e.g., `__import__('os').system('...')` though `__import__` was handled via dunder exclusion, other calls could still pass if their dependencies are met or via other tricks).
+**Learning:** When validating AST trees for dynamic type evaluation using `eval()`, allowing generic `ast.Call` nodes introduces a critical Arbitrary Code Execution (ACE) vulnerability, as it permits execution of any callable in the module's global namespace.
+**Prevention:** `ast.Call` nodes must be strictly whitelisted to specific, required functions (e.g., `Depends`, `Field`, `depends`, `PrivateAttr`) to prevent ACE.

--- a/src/codeweaver/core/di/container.py
+++ b/src/codeweaver/core/di/container.py
@@ -138,6 +138,17 @@ class Container[T]:
 
                 super().generic_visit(node)
 
+            def visit_Call(self, node: ast.Call) -> None:
+                # Restrict ast.Call nodes to a specific whitelist to prevent Arbitrary Code Execution (ACE)
+                # vulnerabilities during dynamic type string evaluation using restricted eval.
+                if not (
+                    isinstance(node.func, ast.Name)
+                    and node.func.id in {"Depends", "Field", "depends", "PrivateAttr"}
+                ):
+                    func_name = getattr(node.func, "id", type(node.func).__name__)
+                    raise TypeError(f"Forbidden function call in type string: {func_name}")
+                self.generic_visit(node)
+
         try:
             TypeValidator().visit(tree)
         except TypeError:


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Found a vulnerability in `_safe_eval_type` in `src/codeweaver/core/di/container.py` where allowing generic `ast.Call` nodes during AST validation before an `eval()` call could lead to Arbitrary Code Execution (ACE) if an attacker injects a malicious function call.
🎯 **Impact:** An attacker could execute arbitrary code within the host machine's environment if they are able to control the string evaluated.
🔧 **Fix:** Added a `visit_Call` method inside `TypeValidator` to strictly whitelist `ast.Call` nodes to specific, required functions (`Depends`, `Field`, `depends`, `PrivateAttr`).
✅ **Verification:** Verified by targeted testing of security tests `uv run pytest tests/di/test_container_security.py` as well as full unit tests.

---
*PR created automatically by Jules for task [9261490303314997612](https://jules.google.com/task/9261490303314997612) started by @bashandbone*

## Summary by Sourcery

Harden dynamic type evaluation by restricting allowed function calls in AST validation to prevent arbitrary code execution.

Bug Fixes:
- Prevent arbitrary code execution in `_safe_eval_type` by whitelisting allowed `ast.Call` targets in the DI container type resolution.
- Document the newly identified AST-based eval vulnerability and its mitigation steps in the Sentinel security log.

Documentation:
- Extend `.jules/sentinel.md` with details of the AST call restriction vulnerability, lessons learned, and preventive guidance.