### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Arbitrary Code Execution vulnerability in type annotation evaluation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,10 @@
 **Vulnerability:** Found an unused `_attempt_import` function in `src/codeweaver/server/mcp/server.py` that dynamically imports a module directly from unvalidated configuration (`import_module(mw.rsplit(".", 1)[0])`), leading to potential arbitrary code execution.
 **Learning:** Functions that perform dynamic imports should not be left around in the codebase if they are unused, especially if they are designed to take unvalidated strings as input.
 **Prevention:** Avoid dynamic imports based on configuration or inputs without strict whitelisting. Use tools like `semgrep` with python security rules to actively catch these patterns.
+<!-- SPDX-FileCopyrightText: 2025 Knitli Inc. -->
+<!-- SPDX-License-Identifier: MIT OR Apache-2.0 -->
+
+## 2025-02-25 - Prevent Arbitrary Code Execution (ACE) in Safe AST Evaluation
+**Vulnerability:** Safe AST evaluation logic for resolving dynamic type annotations in `src/codeweaver/core/di/container.py` allowed unrestricted `ast.Call` nodes. This permitted the evaluation of arbitrary callables present in the global namespace during type hint parsing (e.g., `Annotated[int, os.system('...')]`), leading to a critical Arbitrary Code Execution (ACE) vulnerability.
+**Learning:** Even when builtins are restricted (e.g., overriding `__builtins__` in `eval()`), allowing function calls in an AST passed to `eval` can be extremely dangerous if the global namespace or allowed AST nodes are not strictly controlled.
+**Prevention:** Implement an explicit whitelist for `ast.Call` nodes, allowing only specifically required functions (e.g., `Depends`, `depends`, `Field`, `PrivateAttr`, `Tag`). Verify that any added functions are strictly necessary for the application's functionality.

--- a/src/codeweaver/core/di/container.py
+++ b/src/codeweaver/core/di/container.py
@@ -130,6 +130,14 @@ class Container[T]:
                 ):
                     raise TypeError(f"Forbidden AST node in type string: {type(node).__name__}")
 
+                # Restrict Arbitrary Code Execution (ACE) via type hints by strictly whitelisting ast.Call
+                if isinstance(node, ast.Call):
+                    if isinstance(node.func, ast.Name):
+                        if node.func.id not in {"Depends", "depends", "Field", "PrivateAttr", "Tag"}:
+                            raise TypeError(f"Forbidden call in type string: {node.func.id}")
+                    else:
+                        raise TypeError("Forbidden call in type string: only simple names are allowed")
+
                 # Block dunder access to prevent escaping the restricted environment
                 if isinstance(node, ast.Name) and node.id.startswith("__"):
                     raise TypeError(f"Forbidden dunder name: {node.id}")


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unrestricted `ast.Call` node parsing in dynamic type evaluation in `src/codeweaver/core/di/container.py` permitted any callable in the global scope (e.g. `os.system`) to be executed during resolution. 
🎯 **Impact:** Allowed Arbitrary Code Execution (ACE) under the guise of dependency type injection/resolution.
🔧 **Fix:** Strictly restricted allowed `ast.Call` names to well-known safe functions required for framework behavior: `Depends`, `depends`, `Field`, `PrivateAttr`, and `Tag`.
✅ **Verification:** Verify tests pass and that attempting to dynamically resolve unsafe string types like `Annotated[int, print()]` explicitly raises a `TypeError`.

---
*PR created automatically by Jules for task [4029442110563029413](https://jules.google.com/task/4029442110563029413) started by @bashandbone*

## Summary by Sourcery

Harden safe AST evaluation for dynamic type annotations to prevent arbitrary code execution and document the security fix in Sentinel notes.

Bug Fixes:
- Prevent arbitrary code execution via dynamic type annotation evaluation by restricting allowed ast.Call targets to a small set of safe framework functions.

Documentation:
- Document the AST evaluation arbitrary code execution vulnerability, its root cause, and prevention measures in the Sentinel security log.