### PR TITLE
⚡ Bolt: Optimize linear lookups in file extension checking

### DIFF
--- a/src/codeweaver/core/metadata.py
+++ b/src/codeweaver/core/metadata.py
@@ -247,7 +247,13 @@ class ExtLangPair(NamedTuple):
         """Check if the extension is a documentation file."""
         from codeweaver.core.file_extensions import DOC_FILES_EXTENSIONS
 
-        return next((True for doc_ext in DOC_FILES_EXTENSIONS if doc_ext.ext == self.ext), False)
+        # Optimization: Standard for loop with early return is significantly faster
+        # than next() with a generator comprehension for linear lookups, as it avoids
+        # the overhead of allocating a generator frame.
+        for doc_ext in DOC_FILES_EXTENSIONS:  # noqa: SIM110
+            if doc_ext.ext == self.ext:
+                return True
+        return False
 
     @property
     def is_code(self) -> bool:
@@ -259,7 +265,13 @@ class ExtLangPair(NamedTuple):
         """Check if the extension is a data file."""
         from codeweaver.core.file_extensions import DATA_FILES_EXTENSIONS
 
-        return next((True for data_ext in DATA_FILES_EXTENSIONS if data_ext.ext == self.ext), False)
+        # Optimization: Standard for loop with early return is significantly faster
+        # than next() with a generator comprehension for linear lookups, as it avoids
+        # the overhead of allocating a generator frame.
+        for data_ext in DATA_FILES_EXTENSIONS:  # noqa: SIM110
+            if data_ext.ext == self.ext:
+                return True
+        return False
 
     @property
     def as_source(self) -> ChunkSource:


### PR DESCRIPTION
💡 **What**: Replaced the `next()` with generator comprehension pattern used in the `is_doc` and `is_data` property methods of `ChunkKind` (`src/codeweaver/core/metadata.py`) with standard `for` loops utilizing early returns. Added `# noqa: SIM110` to preserve the optimization from Ruff's simplify rules.

🎯 **Why**: In Python, creating a generator comprehension inside `next()` (or `any()`) incurs overhead because it has to allocate a generator frame. For simple linear lookups over a collection (like iterating through `DOC_FILES_EXTENSIONS`), a standard `for` loop with an early return is measurably faster as it bypasses this generator allocation overhead entirely. Since these properties are likely evaluated frequently during file parsing and indexing, this micro-optimization provides a small but consistent speed boost.

📊 **Impact**: Reduces the execution time of `is_doc` and `is_data` extension checks by eliminating generator frame allocation overhead per call, leading to a small improvement in file parsing and metadata resolution speed.

🔬 **Measurement**: Verify by running the test suite (`uv run pytest tests/unit/core/ --no-cov`). The tests pass, ensuring no change in functionality. Performance can be benchmarked using `timeit` comparing the `next(...)` approach vs the `for ... return` approach over a sample array.

---
*PR created automatically by Jules for task [3287533106860394289](https://jules.google.com/task/3287533106860394289) started by @bashandbone*

## Summary by Sourcery

Enhancements:
- Replace generator-based next() usage in ChunkKind.is_doc and ChunkKind.is_data with early-return for loops for faster linear extension lookups.