### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary code execution in dependency container

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,8 @@
 **Vulnerability:** Found an unused `_attempt_import` function in `src/codeweaver/server/mcp/server.py` that dynamically imports a module directly from unvalidated configuration (`import_module(mw.rsplit(".", 1)[0])`), leading to potential arbitrary code execution.
 **Learning:** Functions that perform dynamic imports should not be left around in the codebase if they are unused, especially if they are designed to take unvalidated strings as input.
 **Prevention:** Avoid dynamic imports based on configuration or inputs without strict whitelisting. Use tools like `semgrep` with python security rules to actively catch these patterns.
+
+## 2026-04-22 - Arbitrary Code Execution via Unsafe AST Evaluation
+**Vulnerability:** Found a critical vulnerability in `_safe_eval_type` inside `src/codeweaver/core/di/container.py` where `ast.Call` nodes were unconditionally allowed during AST-based type string evaluation using Python's `eval()`. This allowed arbitrary callable execution within the module namespace.
+**Learning:** Even with an AST `NodeVisitor` ensuring restricted constructs (like disabling dunder access), unconditionally allowing `ast.Call` can be exploited to run system commands or unintended functions if an attacker controls a type annotation string.
+**Prevention:** Strictly enforce a whitelist for `ast.Call` validation checking `node.func.id` to match explicitly required dependencies (e.g., `Depends`, `depends`, `Field`, `PrivateAttr`, `Tag`). Avoid open-ended evaluations by enforcing an allow-only list of node types.

--- a/src/codeweaver/core/di/container.py
+++ b/src/codeweaver/core/di/container.py
@@ -111,7 +111,13 @@ class Container[T]:
                 # - Unions: int | str (BinOp, BitOr)
                 # - Annotated: Annotated[int, Depends(...)] (Call, keyword, Tuple, List)
                 # - Literals: Literal["foo"] (Constant)
-                if not isinstance(
+                if isinstance(node, ast.Call):
+                    # Restricting arbitrary function calls during type evaluation prevents ACE vulnerabilities
+                    if not isinstance(node.func, ast.Name) or node.func.id not in {"Depends", "depends", "Field", "PrivateAttr", "Tag"}:
+                        raise TypeError(f"Forbidden function call in type string: {node.func.id if isinstance(node.func, ast.Name) else type(node.func).__name__}")
+                elif isinstance(node, ast.keyword):
+                    pass
+                elif not isinstance(
                     node,
                     (
                         ast.Expression,
@@ -124,8 +130,6 @@ class Container[T]:
                         ast.Load,
                         ast.Tuple,
                         ast.List,
-                        ast.Call,
-                        ast.keyword,
                     ),
                 ):
                     raise TypeError(f"Forbidden AST node in type string: {type(node).__name__}")


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `_safe_eval_type` function allowed arbitrary `ast.Call` execution during Pydantic/dependency string type resolution (Arbitrary Code Execution via `eval()`).
🎯 Impact: Attackers who could control a configuration that maps to a type string or those manipulating dependency annotations could execute arbitrary callables directly from the OS, bypassing access controls.
🔧 Fix: Removed `ast.Call` from the global unconditionally allowed list in `TypeValidator.generic_visit`. Implemented a targeted allowlist allowing only explicitly required dependency wrappers (`Depends`, `depends`, `Field`, `PrivateAttr`, `Tag`).
✅ Verification: Ran `mise //:test` on the `tests/unit/core/` and the system passed successfully without regressions. Tested the local exploit bypassing the ast logic and it threw a forbidden exception safely.

---
*PR created automatically by Jules for task [3732493649190943774](https://jules.google.com/task/3732493649190943774) started by @bashandbone*

## Summary by Sourcery

Harden AST-based type string evaluation in the dependency injection container to prevent arbitrary function execution and document the security fix in Sentinel notes.

Bug Fixes:
- Block arbitrary ast.Call execution in _safe_eval_type by only allowing specific, trusted dependency wrappers in type annotations.

Documentation:
- Add Sentinel security incident entry describing the unsafe AST evaluation vulnerability, its impact, and prevention guidance.