### PR TITLE
⚡ Bolt: [performance improvement] Replace O(N²) nested loop with O(N) hash map lookup in reranker

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,7 +13,7 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 
 # 2026-03-29 -  Consider Readability and Possible Environment Limitations
 **Learning** While some patterns are hypothetically faster, they may not improve performance in i/o bound contexts. Examples include embedding/reranking requests and database operations where the dominant limiting factors are i/o constraints.
-**Action** Don't recommend changes that reduce readability or diverge from Python idioms for no or marginal gains in performance. 
+**Action** Don't recommend changes that reduce readability or diverge from Python idioms for no or marginal gains in performance.
 
 ## 2026-04-01 - Fast generation of line pos lengths in Chunker with itertools
 **Learning:** itertools.accumulate(map(len, lines)) is significantly faster (~2-3x) than using a generator expression like (line_offsets[-1] + len(line) for line in lines) because it pushes the entire loop down to C level instead of creating generator overhead for each element.
@@ -25,3 +25,7 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 ## 2025-04-12 - Walrus Operator Optimization
 **Learning:** Using the walrus operator inside a list comprehension to avoid redundant execution of string methods (like `.strip()`) is an effective and safe micro-optimization. The result of the assignment inside the list comprehension will intentionally leak into the scope of the caller function, but this standard Python behavior does not cause naming conflicts in non-recursive or non-global scopes.
 **Action:** Always favor using the walrus operator `:=` in list comprehensions or conditionals when identical string manipulations (e.g., `.strip()`) or expensive evaluation calls appear repeatedly within the identical expression branch.
+
+## 2024-05-18 - Avoid O(N²) nested loops with generator comprehensions in list building
+**Learning:** In list comprehensions or extending lists (e.g. `extend(...)`), using a generator comprehension like `next((... for x in y if ...))` inside the loop over `N` elements creates an $O(N^2)$ algorithmic complexity if `y` also has `N` elements. This happened in `default_reranking_output_transformer` where `batch_rank` was calculated.
+**Action:** Always precompute a hash map (dictionary lookup) for mapping values outside the loop to change the complexity from $O(N^2)$ to $O(N)$, especially in hot paths like reranking output processing.

--- a/src/codeweaver/providers/reranking/providers/base.py
+++ b/src/codeweaver/providers/reranking/providers/base.py
@@ -91,10 +91,12 @@ def default_reranking_output_transformer(
     mapped_scores = sorted(
         ((i, score) for i, score in enumerate(results)), key=lambda x: x[1], reverse=True
     )
+    # Replace O(N^2) generator comprehension lookup with O(N) hash map lookup
+    rank_lookup = {idx: j + 1 for j, (idx, _) in enumerate(mapped_scores)}
     processed_results.extend(
         RerankingResult(
             original_index=i,
-            batch_rank=next((j + 1 for j, (idx, _) in enumerate(mapped_scores) if idx == i), -1),
+            batch_rank=rank_lookup.get(i, -1),
             score=score,
             chunk=chunk,
         )


### PR DESCRIPTION
💡 What: In `default_reranking_output_transformer`, a generator comprehension with `next()` was used inside a loop over $N$ items to find the rank of each item from a list of $N$ items. This was replaced with a precomputed hash map (`rank_lookup`).
🎯 Why: The previous implementation had an $O(N^2)$ algorithmic complexity because it performed a linear scan for each element in the worst case. The new implementation precomputes a lookup table, bringing the total complexity down to $O(N)$.
📊 Impact: Expected performance improvement in processing outputs for large numbers of reranked chunks. Testing locally showed significant speedups for `N=500` and higher.
🔬 Measurement: Verify the logic by looking at tests for `RerankingProvider` implementations or running `mise //:test tests/unit/providers`.

---
*PR created automatically by Jules for task [1239632412642915857](https://jules.google.com/task/1239632412642915857) started by @bashandbone*

## Summary by Sourcery

Optimize reranking output transformation by replacing quadratic-time rank computation with a linear-time dictionary-based lookup and document the performance guideline in the Bolt playbook.

Enhancements:
- Precompute a rank lookup dictionary in `default_reranking_output_transformer` to avoid O(N²) generator-based searches when assigning `batch_rank`.
- Document a new Bolt guideline advising against using nested generator-based lookups in list building when they cause quadratic complexity, recommending hash map precomputation instead.