### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary code execution in type evaluation via restricted AST call whitelist

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,8 @@
 **Vulnerability:** Found an unused `_attempt_import` function in `src/codeweaver/server/mcp/server.py` that dynamically imports a module directly from unvalidated configuration (`import_module(mw.rsplit(".", 1)[0])`), leading to potential arbitrary code execution.
 **Learning:** Functions that perform dynamic imports should not be left around in the codebase if they are unused, especially if they are designed to take unvalidated strings as input.
 **Prevention:** Avoid dynamic imports based on configuration or inputs without strict whitelisting. Use tools like `semgrep` with python security rules to actively catch these patterns.
+
+## 2026-04-21 - ACE vulnerability in eval during AST validation
+**Vulnerability:** A critical Arbitrary Code Execution (ACE) vulnerability was found in `src/codeweaver/core/di/container.py` during type resolution string evaluation (`_safe_eval_type`). The `TypeValidator` broadly allowed generic `ast.Call` nodes before calling `eval()` on type strings, permitting the execution of any callable mapped in the `globalns` parameter.
+**Learning:** Even when using a restrictive AST check before executing `eval()`, implicitly allowing generic `ast.Call` nodes effectively bypasses the restricted sandbox by allowing any accessible function to be invoked during evaluation.
+**Prevention:** Strictly whitelist allowed function names (e.g. `Depends`, `Field`, `Tag`) when validating `ast.Call` nodes in type strings before calling `eval()`, preventing any unauthorized code execution.

--- a/src/codeweaver/core/di/container.py
+++ b/src/codeweaver/core/di/container.py
@@ -130,6 +130,24 @@ class Container[T]:
                 ):
                     raise TypeError(f"Forbidden AST node in type string: {type(node).__name__}")
 
+                # 🛡️ Sentinel: Prevent Arbitrary Code Execution (ACE)
+                # Allowing generic ast.Call nodes permits execution of any callable
+                # in the module's global namespace via eval() below. We strictly
+                # whitelist required functions to eliminate this critical ACE vulnerability.
+                if isinstance(node, ast.Call) and (
+                    not isinstance(node.func, ast.Name)
+                    or node.func.id
+                    not in {
+                        "Depends",
+                        "depends",
+                        "Field",
+                        "PrivateAttr",
+                        "Tag",
+                    }
+                ):
+                    func_name = getattr(node.func, "id", "unknown")
+                    raise TypeError(f"Forbidden function call in type string: {func_name}")
+
                 # Block dunder access to prevent escaping the restricted environment
                 if isinstance(node, ast.Name) and node.id.startswith("__"):
                     raise TypeError(f"Forbidden dunder name: {node.id}")


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `_safe_eval_type` function in `src/codeweaver/core/di/container.py` contained an Arbitrary Code Execution (ACE) vulnerability. The custom `TypeValidator` loosely permitted any `ast.Call` nodes when checking type strings before evaluating them with `eval()`. This allowed the execution of any callable mapped in the `globalns` parameter.
🎯 Impact: An attacker could potentially inject malicious functions or payloads into type string configurations, resulting in arbitrary code execution within the execution environment. 
🔧 Fix: Implemented strict whitelisting for `ast.Call` nodes inside `TypeValidator.generic_visit()`. It now only accepts function calls to `Depends`, `depends`, `Field`, `PrivateAttr`, and `Tag`. An inline security comment was added addressing the ACE concern, as required.
✅ Verification: Tested against a local script injecting a malicious function (`execute_evil`) into a type string annotation. It now securely fails with a `TypeError` instead of allowing the execution. Also ran the test suite locally ensuring no regression.

---
*PR created automatically by Jules for task [289020645167947115](https://jules.google.com/task/289020645167947115) started by @bashandbone*

## Summary by Sourcery

Harden type string evaluation by restricting allowed AST function calls and document the associated ACE vulnerability and mitigation in the Sentinel security log.

Bug Fixes:
- Prevent arbitrary code execution in type evaluation by rejecting non-whitelisted ast.Call nodes in the TypeValidator used by _safe_eval_type.

Documentation:
- Add a Sentinel security log entry describing the ACE vulnerability in eval-based type resolution and the whitelisting-based fix.