### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary code execution in AST type evaluation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,7 @@
 **Vulnerability:** Found an unused `_attempt_import` function in `src/codeweaver/server/mcp/server.py` that dynamically imports a module directly from unvalidated configuration (`import_module(mw.rsplit(".", 1)[0])`), leading to potential arbitrary code execution.
 **Learning:** Functions that perform dynamic imports should not be left around in the codebase if they are unused, especially if they are designed to take unvalidated strings as input.
 **Prevention:** Avoid dynamic imports based on configuration or inputs without strict whitelisting. Use tools like `semgrep` with python security rules to actively catch these patterns.
+## 2025-02-14 - Arbitrary Code Execution (ACE) via AST Call Evaluation
+**Vulnerability:** Allowed arbitrary `ast.Call` nodes in type annotation evaluation strings, potentially leading to arbitrary code execution if user input or malicious type strings are evaluated.
+**Learning:** `eval()` inherently supports execution even within restricted builtins environments. By allowing generic `ast.Call` nodes when traversing AST for type annotation resolution, the system accidentally permitted invocation of any callable residing in the target global namespace.
+**Prevention:** Strictly limited the `ast.Call` nodes to a tightly controlled whitelist of known safe functions used directly within type annotations (`Depends`, `depends`, `Field`, `PrivateAttr`, `Tag`). Any unexpected callables during AST inspection will correctly raise a `TypeError` before `eval()` executes.

--- a/src/codeweaver/core/di/container.py
+++ b/src/codeweaver/core/di/container.py
@@ -136,6 +136,26 @@ class Container[T]:
                 if isinstance(node, ast.Attribute) and node.attr.startswith("__"):
                     raise TypeError(f"Forbidden dunder attribute: {node.attr}")
 
+                # 🛡️ Sentinel Security Fix: Whitelist ast.Call functions
+                # Allowing generic ast.Call nodes could lead to Arbitrary Code Execution (ACE)
+                # during eval() as it permits running any callable in the global namespace.
+                # We strictly limit ast.Call usage to known safe functions used in annotations.
+                if isinstance(node, ast.Call) and (
+                    not isinstance(node.func, ast.Name)
+                    or node.func.id
+                    not in {
+                        "Depends",
+                        "depends",
+                        "Field",
+                        "PrivateAttr",
+                        "Tag",
+                    }
+                ):
+                    func_name = (
+                        node.func.id if isinstance(node.func, ast.Name) else str(type(node.func))
+                    )
+                    raise TypeError(f"Forbidden function call in type string: {func_name}")
+
                 super().generic_visit(node)
 
         try:


### PR DESCRIPTION
**🚨 Severity:** CRITICAL
**💡 Vulnerability:** The `TypeValidator` used before resolving typing annotations with `eval()` allowed any `ast.Call` to pass validation. This meant an attacker who could control type annotation strings (e.g., dynamically generated or user-provided) could execute arbitrary code functions present in the target module's namespace.
**🎯 Impact:** A malicious user or external plugin could gain arbitrary code execution (ACE) privileges on the server or developer machine.
**🔧 Fix:** Added a whitelist strictly limiting allowable functions inside `ast.Call` nodes to those natively used for DI annotations (i.e. `Depends`, `depends`, `Field`, `PrivateAttr`, `Tag`). Any other call function correctly throws a `TypeError`.
**✅ Verification:** Ran formatting and comprehensive unit tests (`tests/unit/core/`) ensuring existing DI resolutions properly continue functioning while unsafe eval behaviors are mitigated.

---
*PR created automatically by Jules for task [13648616864975803255](https://jules.google.com/task/13648616864975803255) started by @bashandbone*

## Summary by Sourcery

Harden type annotation evaluation to prevent arbitrary code execution during dependency injection AST processing.

Bug Fixes:
- Reject unsafe ast.Call nodes in type annotation strings by enforcing a strict whitelist of allowed call targets used for dependency-injection-related annotations.

Documentation:
- Document the new AST call evaluation vulnerability, its root cause, and the whitelist-based prevention in the Sentinel security log.