### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Arbitrary Code Execution in AST validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,8 @@
 **Vulnerability:** Found an unused `_attempt_import` function in `src/codeweaver/server/mcp/server.py` that dynamically imports a module directly from unvalidated configuration (`import_module(mw.rsplit(".", 1)[0])`), leading to potential arbitrary code execution.
 **Learning:** Functions that perform dynamic imports should not be left around in the codebase if they are unused, especially if they are designed to take unvalidated strings as input.
 **Prevention:** Avoid dynamic imports based on configuration or inputs without strict whitelisting. Use tools like `semgrep` with python security rules to actively catch these patterns.
+
+## 2026-05-28 - [Arbitrary Code Execution in AST Validation]
+**Vulnerability:** Found a vulnerability in `src/codeweaver/core/di/container.py` where generic `ast.Call` nodes were permitted during AST validation for string type resolution, which is later passed to `eval`. This permitted the execution of any callable in the restricted eval's global namespace, posing an Arbitrary Code Execution (ACE) risk.
+**Learning:** Permitting generic `ast.Call` in validation nodes that precede `eval()` without validating the actual function being called defeats the purpose of the sandbox.
+**Prevention:** Strictly whitelist all callable names and restrict the nodes to direct function calls when traversing ASTs for safe `eval` validation.

--- a/src/codeweaver/core/di/container.py
+++ b/src/codeweaver/core/di/container.py
@@ -136,6 +136,13 @@ class Container[T]:
                 if isinstance(node, ast.Attribute) and node.attr.startswith("__"):
                     raise TypeError(f"Forbidden dunder attribute: {node.attr}")
 
+                # Security: Restrict callable nodes in `eval` to prevent Arbitrary Code Execution (ACE)
+                if isinstance(node, ast.Call):
+                    if not isinstance(node.func, ast.Name):
+                        raise TypeError("Only direct function calls are allowed in type annotations")
+                    if node.func.id not in {"Depends", "depends", "Field", "PrivateAttr", "Tag"}:
+                        raise TypeError(f"Forbidden function call in type annotation: {node.func.id}")
+
                 super().generic_visit(node)
 
         try:


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Generic `ast.Call` nodes were allowed during AST type parsing in `TypeValidator.generic_visit` within `src/codeweaver/core/di/container.py`. This input was subsequently fed to `eval()`. Without whitelisting, this allowed the execution of any callable in the restricted eval's global namespace, posing a potential Arbitrary Code Execution (ACE) risk.
🎯 Impact: An attacker who can control the string representation of a type annotation (e.g., via malicious configuration or dependency injection inputs) could execute arbitrary functions available in the module's global scope, compromising the security of the application.
🔧 Fix: Added a strict whitelist for `ast.Call` nodes in `TypeValidator.generic_visit`, limiting allowable functions strictly to safe known ones: `Depends`, `depends`, `Field`, `PrivateAttr`, and `Tag`.
✅ Verification: Ran unit tests using `pytest` for `core`, `engine`, and `server` packages to verify that no dependency injection logic or container behavior was broken, and that the ACE vector is closed.

---
*PR created automatically by Jules for task [4563127322899614225](https://jules.google.com/task/4563127322899614225) started by @bashandbone*

## Summary by Sourcery

Harden AST-based type annotation validation to prevent arbitrary code execution during eval of string annotations.

Bug Fixes:
- Restrict allowed function calls in type-annotation ASTs to a small, safe whitelist to close an arbitrary code execution vector.

Documentation:
- Document the newly discovered AST validation arbitrary code execution vulnerability and its mitigation steps in the Sentinel security log.