### PR TITLE
⚡ Bolt: Optimize batch rank lookup complexity

### DIFF
--- a/src/codeweaver/providers/reranking/providers/base.py
+++ b/src/codeweaver/providers/reranking/providers/base.py
@@ -91,10 +91,12 @@ def default_reranking_output_transformer(
     mapped_scores = sorted(
         ((i, score) for i, score in enumerate(results)), key=lambda x: x[1], reverse=True
     )
+    # ⚡ Bolt: Precompute rank mapping to reduce lookup algorithmic complexity from O(N^2) to O(N)
+    rank_map = {idx: j + 1 for j, (idx, _) in enumerate(mapped_scores)}
     processed_results.extend(
         RerankingResult(
             original_index=i,
-            batch_rank=next((j + 1 for j, (idx, _) in enumerate(mapped_scores) if idx == i), -1),
+            batch_rank=rank_map.get(i, -1),
             score=score,
             chunk=chunk,
         )


### PR DESCRIPTION
💡 **What**: Replaced the `next(...)` generator expression with a precomputed dictionary mapping (`rank_map`) to perform $O(1)$ lookups.
🎯 **Why**: The original implementation performed an $O(N)$ generator search inside an $O(N)$ loop, resulting in $O(N^2)$ algorithmic complexity for batch rank assignment. By precomputing the ranks, we avoid scanning the entire list for every single element.
📊 **Impact**: This drastically reduces overhead, yielding a significantly faster batch reranking process when handling large chunk arrays.
🔬 **Measurement**: The impact and correctness can be verified by observing `default_reranking_output_transformer` benchmarks and executing the targeted test suite using `uv run pytest tests/unit/providers/reranking/ --no-cov`.

---
*PR created automatically by Jules for task [5058674090919253659](https://jules.google.com/task/5058674090919253659) started by @bashandbone*

## Summary by Sourcery

Enhancements:
- Precompute a rank mapping for reranking results to achieve O(N) batch rank assignment instead of O(N^2).