### PR TITLE
🛡️ Sentinel: [CRITICAL] Prevent Arbitrary Code Execution in type evaluations

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,8 @@
 **Vulnerability:** Found an unused `_attempt_import` function in `src/codeweaver/server/mcp/server.py` that dynamically imports a module directly from unvalidated configuration (`import_module(mw.rsplit(".", 1)[0])`), leading to potential arbitrary code execution.
 **Learning:** Functions that perform dynamic imports should not be left around in the codebase if they are unused, especially if they are designed to take unvalidated strings as input.
 **Prevention:** Avoid dynamic imports based on configuration or inputs without strict whitelisting. Use tools like `semgrep` with python security rules to actively catch these patterns.
+
+## 2026-04-22 - Prevent Arbitrary Code Execution in dynamic type evaluation
+**Vulnerability:** The `Container._safe_eval_type` method evaluates string representations of type annotations using an AST validation approach. It previously allowed generic `ast.Call` nodes to exist without verifying the underlying function being called.
+**Learning:** Allowing generic `ast.Call` nodes in type validators evaluating user or external inputs introduces a critical Arbitrary Code Execution (ACE) vulnerability, because it permits executing any function accessible in the module's global namespace or `__builtins__` during the eval phase.
+**Prevention:** `ast.Call` nodes must be strictly whitelisted to the specific set of expected functions (like `Depends`, `depends`, `Field`, `PrivateAttr`, `Tag`, `Parameter`, `cast`, `length`, `uuid7`). Use rigorous AST node restriction and do not allow unbounded execution of methods when parsing types from string evaluation mechanisms.

--- a/src/codeweaver/core/di/container.py
+++ b/src/codeweaver/core/di/container.py
@@ -84,7 +84,7 @@ class Container[T]:
         self._request_cache: dict[Any, Any] = {}  # Keys can be types or callables
         self._providers_loaded: bool = False  # Track if auto-discovery has run
 
-    def _safe_eval_type(self, type_str: str, globalns: dict[str, Any]) -> Any | None:
+    def _safe_eval_type(self, type_str: str, globalns: dict[str, Any]) -> Any | None:  # noqa: C901
         """Safely evaluate a type string using AST validation.
 
         Parses the type string into an AST, validates that it contains only safe
@@ -137,6 +137,31 @@ class Container[T]:
                     raise TypeError(f"Forbidden dunder attribute: {node.attr}")
 
                 super().generic_visit(node)
+
+            def visit_Call(self, node: ast.Call) -> None:
+                # Restricting generic ast.Call nodes to a specific whitelist
+                # prevents Arbitrary Code Execution (ACE) vulnerabilities during type evaluation.
+                allowed_functions = frozenset({
+                    "Depends",
+                    "Field",
+                    "Parameter",
+                    "PrivateAttr",
+                    "Tag",
+                    "cast",
+                    "depends",
+                    "length",
+                    "uuid7",
+                })
+                func_name = None
+                if isinstance(node.func, ast.Name):
+                    func_name = node.func.id
+                elif isinstance(node.func, ast.Attribute):
+                    func_name = node.func.attr
+
+                if func_name not in allowed_functions:
+                    raise TypeError(f"Forbidden function call in type string: {func_name}")
+
+                self.generic_visit(node)
 
         try:
             TypeValidator().visit(tree)


### PR DESCRIPTION
🚨 **Severity:** CRITICAL

💡 **Vulnerability:**
The `Container._safe_eval_type` function evaluates type strings by constructing an Abstract Syntax Tree (AST) using `ast.parse` and then ensuring it is "safe" before calling Python's `eval()` on it. Previously, it allowed all generic `ast.Call` nodes to be present in the tree. Because the AST was ultimately compiled and passed to `eval()` with the module's `globalns`, this flaw inherently allowed evaluating strings to invoke *any* callable within the `globalns` dictionary or Python's `__builtins__`, resulting in an Arbitrary Code Execution (ACE) vulnerability. 

🎯 **Impact:**
If an attacker could manipulate or inject arbitrary string type representations that `_safe_eval_type` processes (potentially through type inference APIs, dependency injection configurations, or dynamic parsing mechanisms), they could inject malicious `ast.Call` nodes. Since it fell through to `eval()`, it could be used to execute unintended underlying logic with the permissions of the application process.

🔧 **Fix:**
Implemented a strict node validation layer by overriding the `visit_Call` method in the `TypeValidator` class. Now, `ast.Call` nodes are strongly restricted. If an `ast.Call` appears in the type string tree, it validates that the function call strictly matches a specific, hardcoded whitelist of expected dependency injection and type system functions (e.g., `Depends`, `Parameter`, `Field`, `PrivateAttr`, `Tag`). Any unexpected callable throws a `TypeError`, aborting the evaluation before `eval()` can be reached. An inline comment explaining the security concern was added alongside the fix.

✅ **Verification:**
1. Confirmed local changes explicitly enforce whitelist logic with `ast.Call` evaluations.
2. Verified functionality using the primary backend test suite for `core/di/` via `pytest`.
3. Validated proper linting formatting passing `mise //:check`.
4. Logged finding correctly inside `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [6024749506626654658](https://jules.google.com/task/6024749506626654658) started by @bashandbone*

## Summary by Sourcery

Harden type string evaluation in the DI container to prevent arbitrary code execution and document the associated Sentinel security finding.

Bug Fixes:
- Disallow arbitrary function calls in `_safe_eval_type` by validating `ast.Call` nodes against a strict whitelist of permitted functions before evaluation.

Enhancements:
- Annotate `_safe_eval_type` with a complexity linter override and add inline documentation explaining the security rationale for restricting `ast.Call` nodes.

Documentation:
- Record the new Arbitrary Code Execution vulnerability and its mitigation details in `.jules/sentinel.md` for future security tracking.