### PR TITLE
⚡ Bolt: Use O(1) hash map lookup for batch_rank assignment in default_reranking_output_transformer

### DIFF
--- a/src/codeweaver/providers/reranking/providers/base.py
+++ b/src/codeweaver/providers/reranking/providers/base.py
@@ -91,10 +91,12 @@ def default_reranking_output_transformer(
     mapped_scores = sorted(
         ((i, score) for i, score in enumerate(results)), key=lambda x: x[1], reverse=True
     )
+    # Precompute ranks in O(N) instead of searching in O(N^2)
+    rank_map = {idx: j + 1 for j, (idx, _) in enumerate(mapped_scores)}
     processed_results.extend(
         RerankingResult(
             original_index=i,
-            batch_rank=next((j + 1 for j, (idx, _) in enumerate(mapped_scores) if idx == i), -1),
+            batch_rank=rank_map.get(i, -1),
             score=score,
             chunk=chunk,
         )


### PR DESCRIPTION
💡 What: Replaced an $O(N^2)$ `next()` generator expression with an $O(N)$ pre-computed dictionary hash map for looking up `batch_rank` assignments inside `default_reranking_output_transformer`.
🎯 Why: The previous implementation used a nested generator inside a loop over the results length ($N$), which had an asymptotic time complexity of $O(N^2)$.
📊 Impact: Speeds up standard response processing on rerank batches. Lookups fall from $O(N^2)$ to $O(N)$ making parsing large reranking documents drastically faster.
🔬 Measurement: Run benchmark tests covering `default_reranking_output_transformer` to measure the reduction in CPU computation time.

---
*PR created automatically by Jules for task [15360662012186636373](https://jules.google.com/task/15360662012186636373) started by @bashandbone*

## Summary by Sourcery

Enhancements:
- Improve performance of batch_rank assignment in default_reranking_output_transformer by using a precomputed index-to-rank map instead of repeated generator-based searches.