### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary code execution in AST eval

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,7 @@
 **Vulnerability:** Found an unused `_attempt_import` function in `src/codeweaver/server/mcp/server.py` that dynamically imports a module directly from unvalidated configuration (`import_module(mw.rsplit(".", 1)[0])`), leading to potential arbitrary code execution.
 **Learning:** Functions that perform dynamic imports should not be left around in the codebase if they are unused, especially if they are designed to take unvalidated strings as input.
 **Prevention:** Avoid dynamic imports based on configuration or inputs without strict whitelisting. Use tools like `semgrep` with python security rules to actively catch these patterns.
+## 2026-06-04 - Arbitrary Code Execution in AST eval
+**Vulnerability:** Found that when validating AST trees for dynamic type evaluation using `eval()`, allowing generic `ast.Call` nodes introduced an Arbitrary Code Execution (ACE) vulnerability, permitting the execution of any callable in the module's global namespace.
+**Learning:** `ast.Call` nodes in type annotations (e.g., inside `Annotated[]`) must be strictly validated. Merely allowing `ast.Call` as a node type is insufficient if `eval()` is subsequently called, as it can execute unintended functions.
+**Prevention:** Strictly whitelist allowed functions in `ast.Call` nodes (e.g., `Depends`, `depends`, `Field`, `PrivateAttr`, `Tag`, `Parameter`) by checking the node's function name before permitting the node in the AST validation step.

--- a/src/codeweaver/core/di/container.py
+++ b/src/codeweaver/core/di/container.py
@@ -84,7 +84,7 @@ class Container[T]:
         self._request_cache: dict[Any, Any] = {}  # Keys can be types or callables
         self._providers_loaded: bool = False  # Track if auto-discovery has run
 
-    def _safe_eval_type(self, type_str: str, globalns: dict[str, Any]) -> Any | None:
+    def _safe_eval_type(self, type_str: str, globalns: dict[str, Any]) -> Any | None:  # noqa: C901
         """Safely evaluate a type string using AST validation.
 
         Parses the type string into an AST, validates that it contains only safe
@@ -135,6 +135,19 @@ class Container[T]:
                     raise TypeError(f"Forbidden dunder name: {node.id}")
                 if isinstance(node, ast.Attribute) and node.attr.startswith("__"):
                     raise TypeError(f"Forbidden dunder attribute: {node.attr}")
+
+                # Security concern: ast.Call permits arbitrary code execution during eval.
+                # Must strictly whitelist allowed functions used in type annotations.
+                if isinstance(node, ast.Call):
+                    allowed_funcs = {"Depends", "depends", "Field", "PrivateAttr", "Tag", "Parameter"}
+                    func_name = None
+                    if isinstance(node.func, ast.Name):
+                        func_name = node.func.id
+                    elif isinstance(node.func, ast.Attribute):
+                        func_name = node.func.attr
+
+                    if func_name not in allowed_funcs:
+                        raise TypeError(f"Forbidden function call in type string: {func_name}")
 
                 super().generic_visit(node)
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The application was using `eval()` to dynamically resolve type annotations from strings. It validated the AST structure to only permit safe nodes. However, it blindly allowed generic `ast.Call` nodes. This created an Arbitrary Code Execution (ACE) vulnerability, because any valid callable existing in the `globalns` dictionary (or builtins) could be executed during evaluation if present in the type string.
🎯 **Impact:** An attacker who could control or inject a malicious type string could potentially execute arbitrary code on the host machine.
🔧 **Fix:** Implemented strict whitelisting within `TypeValidator.generic_visit()`. When an `ast.Call` node is encountered, the code now explicitly checks that the function being called is specifically one of the intended whitelisted functions (`Depends`, `depends`, `Field`, `PrivateAttr`, `Tag`, `Parameter`). If the function call does not match the whitelist, a `TypeError` is raised, preventing the evaluation.
✅ **Verification:** Verified by code review, unit tests (`tests/unit/core/`), and integration tests (`tests/integration/providers/`).

---
*PR created automatically by Jules for task [17667289194909456202](https://jules.google.com/task/17667289194909456202) started by @bashandbone*

## Summary by Sourcery

Harden type-string evaluation by restricting callable usage in AST-based validation and document the resolved arbitrary code execution vulnerability in Sentinel notes.

Bug Fixes:
- Prevent arbitrary code execution during type-string evaluation by rejecting non-whitelisted function calls in AST `Call` nodes.

Documentation:
- Extend Sentinel security notes with details of the AST eval arbitrary code execution vulnerability and its prevention.