### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary code execution in AST evaluation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,7 @@
 **Vulnerability:** Found an unused `_attempt_import` function in `src/codeweaver/server/mcp/server.py` that dynamically imports a module directly from unvalidated configuration (`import_module(mw.rsplit(".", 1)[0])`), leading to potential arbitrary code execution.
 **Learning:** Functions that perform dynamic imports should not be left around in the codebase if they are unused, especially if they are designed to take unvalidated strings as input.
 **Prevention:** Avoid dynamic imports based on configuration or inputs without strict whitelisting. Use tools like `semgrep` with python security rules to actively catch these patterns.
+## 2026-06-06 - Prevented Arbitrary Code Execution in AST Evaluation
+**Vulnerability:** Found a vulnerability in `src/codeweaver/core/di/container.py` where `ast.Call` nodes were allowed without any whitelisting during dynamic type evaluation via `ast.parse(type_str, mode="eval")`. This could lead to Arbitrary Code Execution (ACE) if an attacker can control the type string being evaluated, as any callable in the module's global namespace could be executed.
+**Learning:** When validating AST trees for dynamic type evaluation using `eval()`, allowing generic `ast.Call` nodes is dangerous. It permits execution of any callable in the module's global namespace.
+**Prevention:** `ast.Call` nodes must be strictly whitelisted to specific, required functions (e.g., `Depends`, `depends`, `Field`, `PrivateAttr`, `Tag`, `Parameter`) when validating an AST before evaluating it.

--- a/src/codeweaver/core/di/container.py
+++ b/src/codeweaver/core/di/container.py
@@ -84,7 +84,7 @@ class Container[T]:
         self._request_cache: dict[Any, Any] = {}  # Keys can be types or callables
         self._providers_loaded: bool = False  # Track if auto-discovery has run
 
-    def _safe_eval_type(self, type_str: str, globalns: dict[str, Any]) -> Any | None:
+    def _safe_eval_type(self, type_str: str, globalns: dict[str, Any]) -> Any | None:  # noqa: C901
         """Safely evaluate a type string using AST validation.
 
         Parses the type string into an AST, validates that it contains only safe
@@ -135,6 +135,18 @@ class Container[T]:
                     raise TypeError(f"Forbidden dunder name: {node.id}")
                 if isinstance(node, ast.Attribute) and node.attr.startswith("__"):
                     raise TypeError(f"Forbidden dunder attribute: {node.attr}")
+
+                # Security: Restrict ast.Call nodes to specific allowed functions to prevent
+                # Arbitrary Code Execution (ACE) vulnerabilities during dynamic type evaluation.
+                if isinstance(node, ast.Call):
+                    func_name = None
+                    if isinstance(node.func, ast.Name):
+                        func_name = node.func.id
+                    elif isinstance(node.func, ast.Attribute):
+                        func_name = node.func.attr
+
+                    if func_name not in {"Depends", "depends", "Field", "PrivateAttr", "Tag", "Parameter"}:
+                        raise TypeError(f"Forbidden function call in type string: {func_name}")
 
                 super().generic_visit(node)
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Found a vulnerability in `src/codeweaver/core/di/container.py` where `ast.Call` nodes were allowed without any whitelisting during dynamic type evaluation via `ast.parse(type_str, mode="eval")`. 
🎯 **Impact:** This could lead to Arbitrary Code Execution (ACE) if an attacker can control the type string being evaluated, as any callable in the module's global namespace could be executed.
🔧 **Fix:** Restricted `ast.Call` nodes to specific allowed functions (`Depends`, `depends`, `Field`, `PrivateAttr`, `Tag`, `Parameter`) before allowing AST evaluation. Added a `# noqa: C901` comment to fix the complexity error that Ruff flagged. Also added a journal entry to `.jules/sentinel.md`.
✅ **Verification:** Ran `uv run pytest tests/unit/core/di --no-cov` to verify the patch doesn't introduce regressions. Evaluated code via `mise //:format` and `mise //:check`.

---
*PR created automatically by Jules for task [11637076273986893769](https://jules.google.com/task/11637076273986893769) started by @bashandbone*

## Summary by Sourcery

Restrict dynamic type AST evaluation to prevent arbitrary code execution via unsafe function calls.

Bug Fixes:
- Block arbitrary function calls in AST-based type string evaluation by whitelisting allowed call targets.

Documentation:
- Document the AST evaluation vulnerability and its mitigation in the Sentinel security journal.