### PR TITLE
⚡ Bolt: O(n) hash map lookup for reranking scores

### DIFF
--- a/src/codeweaver/providers/reranking/providers/base.py
+++ b/src/codeweaver/providers/reranking/providers/base.py
@@ -91,10 +91,14 @@ def default_reranking_output_transformer(
     mapped_scores = sorted(
         ((i, score) for i, score in enumerate(results)), key=lambda x: x[1], reverse=True
     )
+
+    # Performance: Pre-compute rank map to avoid O(n^2) algorithmic complexity from nested iteration over mapped_scores
+    rank_map = {idx: j + 1 for j, (idx, _) in enumerate(mapped_scores)}
+
     processed_results.extend(
         RerankingResult(
             original_index=i,
-            batch_rank=next((j + 1 for j, (idx, _) in enumerate(mapped_scores) if idx == i), -1),
+            batch_rank=rank_map.get(i, -1),
             score=score,
             chunk=chunk,
         )


### PR DESCRIPTION
**💡 What:** Pre-compute an $O(n)$ hash map (`rank_map`) of indices to ranks for mapped scores outside the loop, rather than using an $O(n)$ search for every result inside the generator.
**🎯 Why:** The previous code used `next((j + 1 for j, (idx, _) in enumerate(mapped_scores) if idx == i), -1)` inside a generator comprehension iterating over `results`. This resulted in an $O(n^2)$ algorithmic complexity where $n$ is the number of results, causing unnecessary overhead for large result sets.
**📊 Impact:** Reduces the time complexity of the `batch_rank` assignment from $O(n^2)$ to $O(n)$ using $O(1)$ dictionary lookups, significantly improving performance when reranking a large number of chunks.
**🔬 Measurement:** Benchmark `default_reranking_output_transformer` with large collections of results/chunks to verify the reduction in processing time.

---
*PR created automatically by Jules for task [60115920967308526](https://jules.google.com/task/60115920967308526) started by @bashandbone*

## Summary by Sourcery

Enhancements:
- Precompute a rank map from sorted mapped scores and reuse it for batch_rank assignment to reduce algorithmic complexity from O(n^2) to O(n).