### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary code execution vulnerability in AST evaluation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,8 @@
 **Vulnerability:** Found an unused `_attempt_import` function in `src/codeweaver/server/mcp/server.py` that dynamically imports a module directly from unvalidated configuration (`import_module(mw.rsplit(".", 1)[0])`), leading to potential arbitrary code execution.
 **Learning:** Functions that perform dynamic imports should not be left around in the codebase if they are unused, especially if they are designed to take unvalidated strings as input.
 **Prevention:** Avoid dynamic imports based on configuration or inputs without strict whitelisting. Use tools like `semgrep` with python security rules to actively catch these patterns.
+
+## 2026-04-21 - Restrict arbitrary Call nodes in AST dynamic evaluation
+**Vulnerability:** The type validation logic using `ast.parse(type_str, mode="eval")` allowed generic `ast.Call` nodes to pass. Even though standard Python literal types were blocked, any accessible callable within the execution environment's scope could be arbitrarily executed, leading to a critical Arbitrary Code Execution (ACE) vulnerability during type resolution.
+**Learning:** Permitting generic `ast.Call` nodes in type validation allows unauthorized function execution. Allowed AST nodes must be restricted to their expected forms and specific callable identifiers (e.g., `Depends`, `Field`) must be hardcoded or whitelisted.
+**Prevention:** Explicitly restrict allowed callables in the `TypeValidator` to a predefined whitelist instead of broadly allowing the `ast.Call` class. Implement rigorous AST node visitation checks that explicitly validate both `node.func.id` and `node.func.attr`.

--- a/src/codeweaver/core/di/container.py
+++ b/src/codeweaver/core/di/container.py
@@ -136,6 +136,31 @@ class Container[T]:
                 if isinstance(node, ast.Attribute) and node.attr.startswith("__"):
                     raise TypeError(f"Forbidden dunder attribute: {node.attr}")
 
+                # Restricting generic ast.Call nodes prevents arbitrary code execution vulnerabilities
+                # by only permitting safe, expected callables.
+                if isinstance(node, ast.Call):
+                    # Check if the callable is one of the explicitly allowed functions
+                    is_allowed = False
+                    if (isinstance(node.func, ast.Name) and node.func.id in {
+                        "Depends",
+                        "depends",
+                        "Field",
+                        "PrivateAttr",
+                        "Tag",
+                        "Parameter",
+                    }) or (isinstance(node.func, ast.Attribute) and node.func.attr in {
+                        "Depends",
+                        "depends",
+                        "Field",
+                        "PrivateAttr",
+                        "Tag",
+                        "Parameter",
+                    }):
+                        is_allowed = True
+
+                    if not is_allowed:
+                        raise TypeError("Forbidden function call in type string.")
+
                 super().generic_visit(node)
 
         try:


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The type validation logic using `ast.parse(type_str, mode="eval")` allowed generic `ast.Call` nodes to pass. Even though standard Python literal types were blocked, any accessible callable within the execution environment's scope could be arbitrarily executed, leading to a critical Arbitrary Code Execution (ACE) vulnerability during type resolution.
🎯 Impact: An attacker could potentially inject unvalidated configuration strings into the dependency container to achieve arbitrary code execution.
🔧 Fix: Explicitly restrict allowed callables in the `TypeValidator` to a predefined whitelist instead of broadly allowing the `ast.Call` class. Implemented rigorous AST node visitation checks that explicitly validate both `node.func.id` and `node.func.attr`. Allowed specific, required functions like `Depends`, `depends`, `Field`, `PrivateAttr`, `Tag`, and `Parameter`.
✅ Verification: Ran format, lint (`mise //:format`, `mise //:check`), and the test suite (`uv run pytest tests/unit/ tests/di/ --no-cov`) to ensure correct validation logic and no regressions.

---
*PR created automatically by Jules for task [4402007923819433601](https://jules.google.com/task/4402007923819433601) started by @bashandbone*

## Summary by Sourcery

Restrict dynamic AST-evaluated type strings to a small whitelist of safe callable names to close an arbitrary code execution vulnerability in the DI container.

Bug Fixes:
- Block arbitrary function calls in AST-based type validation by only allowing specific whitelisted callables in `TypeValidator`.

Documentation:
- Document the newly fixed AST call-node vulnerability and its mitigation steps in the Sentinel security log.