### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary code execution in AST type evaluation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,8 @@
 **Vulnerability:** Found an unused `_attempt_import` function in `src/codeweaver/server/mcp/server.py` that dynamically imports a module directly from unvalidated configuration (`import_module(mw.rsplit(".", 1)[0])`), leading to potential arbitrary code execution.
 **Learning:** Functions that perform dynamic imports should not be left around in the codebase if they are unused, especially if they are designed to take unvalidated strings as input.
 **Prevention:** Avoid dynamic imports based on configuration or inputs without strict whitelisting. Use tools like `semgrep` with python security rules to actively catch these patterns.
+
+## 2026-04-22 - Arbitrary Code Execution (ACE) via unvalidated ast.Call nodes
+**Vulnerability:** Found that the AST validation for safe type evaluation `_safe_eval_type` in `src/codeweaver/core/di/container.py` allowed generic `ast.Call` nodes. This permitted the evaluation of arbitrary function calls within type hint strings, leading to a critical Arbitrary Code Execution (ACE) vulnerability.
+**Learning:** Permitting generic `ast.Call` nodes during AST-based validation for dynamic evaluation bypasses the intended safety restrictions, as any callable in the global namespace can be executed.
+**Prevention:** `ast.Call` nodes must be strictly evaluated and whitelisted to only allow specific, required functions (e.g., `Depends`, `depends`, `Field`, `PrivateAttr`, `Tag`, `Parameter`) using custom visitor methods like `visit_Call`.

--- a/src/codeweaver/core/di/container.py
+++ b/src/codeweaver/core/di/container.py
@@ -84,7 +84,7 @@ class Container[T]:
         self._request_cache: dict[Any, Any] = {}  # Keys can be types or callables
         self._providers_loaded: bool = False  # Track if auto-discovery has run
 
-    def _safe_eval_type(self, type_str: str, globalns: dict[str, Any]) -> Any | None:
+    def _safe_eval_type(self, type_str: str, globalns: dict[str, Any]) -> Any | None:  # noqa: C901
         """Safely evaluate a type string using AST validation.
 
         Parses the type string into an AST, validates that it contains only safe
@@ -137,6 +137,22 @@ class Container[T]:
                     raise TypeError(f"Forbidden dunder attribute: {node.attr}")
 
                 super().generic_visit(node)
+
+            def visit_Call(self, node: ast.Call) -> None:
+                # Security constraint: Limit allowed function calls to prevent arbitrary code execution (ACE).
+                # Only whitelisted functions are permitted to be evaluated inside type hints.
+                allowed_funcs = {"Depends", "depends", "Field", "PrivateAttr", "Tag", "Parameter"}
+
+                if isinstance(node.func, ast.Name):
+                    if node.func.id not in allowed_funcs:
+                        raise TypeError(f"Forbidden function call: {node.func.id}")
+                elif isinstance(node.func, ast.Attribute):
+                    if node.func.attr not in allowed_funcs:
+                        raise TypeError(f"Forbidden function call attribute: {node.func.attr}")
+                else:
+                    raise TypeError(f"Forbidden function call type: {type(node.func).__name__}")
+
+                self.generic_visit(node)
 
         try:
             TypeValidator().visit(tree)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `_safe_eval_type` function in `src/codeweaver/core/di/container.py` validated type hints by parsing them as AST trees and manually traversing them. However, it permitted generic `ast.Call` nodes without verifying the identity of the function being called. Because these AST nodes are later evaluated using `eval()`, this allowed the arbitrary execution of any callable present in the module's global namespace, leading to a critical Arbitrary Code Execution (ACE) vulnerability.
🎯 Impact: Malicious or unvalidated type hints could execute unauthorized functions, potentially compromising the host system or exposing sensitive environment variables.
🔧 Fix: Added a custom `visit_Call` method to the `TypeValidator` class. This method strictly evaluates the `func` attribute of `ast.Call` nodes and restricts execution to a specific whitelist of known, safe dependency injection and metadata functions used by the framework (`Depends`, `depends`, `Field`, `PrivateAttr`, `Tag`, `Parameter`).
✅ Verification: Ran format, lint, and the entire test suite which completed successfully with no regressions. Verified that `ast.Call` dynamically evaluates the correct dependencies without allowing unauthorized standard library or built-in function executions. Logged in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [3584191746221468630](https://jules.google.com/task/3584191746221468630) started by @bashandbone*

## Summary by Sourcery

Harden AST-based type hint evaluation in the DI container to prevent arbitrary code execution from untrusted type strings and document the incident in Sentinel notes.

Bug Fixes:
- Restrict callable nodes in `_safe_eval_type` AST validation to a whitelist of known-safe DI and metadata helpers, preventing arbitrary function execution during type evaluation.

Documentation:
- Add a Sentinel security entry describing the arbitrary code execution vulnerability in `_safe_eval_type`, its root cause, and the whitelisting-based mitigation.