### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Arbitrary Code Execution in ast.Call dynamic type resolution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,7 @@
 **Vulnerability:** Found an unused `_attempt_import` function in `src/codeweaver/server/mcp/server.py` that dynamically imports a module directly from unvalidated configuration (`import_module(mw.rsplit(".", 1)[0])`), leading to potential arbitrary code execution.
 **Learning:** Functions that perform dynamic imports should not be left around in the codebase if they are unused, especially if they are designed to take unvalidated strings as input.
 **Prevention:** Avoid dynamic imports based on configuration or inputs without strict whitelisting. Use tools like `semgrep` with python security rules to actively catch these patterns.
+## 2026-04-22 - Arbitrary Code Execution via unvalidated ast.Call in Type Resolution
+**Vulnerability:** Found an Arbitrary Code Execution (ACE) vulnerability in `src/codeweaver/core/di/container.py` during dynamic type evaluation via `eval()`. The `TypeValidator` allowed generic `ast.Call` nodes without checking the underlying function being executed, enabling the execution of any callable in the restricted environment's global namespace or provided builtins.
+**Learning:** Even when `eval()` is executed with restricted globals and `__builtins__`, allowing `ast.Call` to execute arbitrary functions present in the namespace can lead to unintended code execution.
+**Prevention:** Strictly validate and whitelist any `ast.Call` nodes when building restricted execution environments to ensure only explicitly trusted functions (e.g., `Depends`, `Field`) are evaluated.

--- a/src/codeweaver/core/di/container.py
+++ b/src/codeweaver/core/di/container.py
@@ -84,7 +84,7 @@ class Container[T]:
         self._request_cache: dict[Any, Any] = {}  # Keys can be types or callables
         self._providers_loaded: bool = False  # Track if auto-discovery has run
 
-    def _safe_eval_type(self, type_str: str, globalns: dict[str, Any]) -> Any | None:
+    def _safe_eval_type(self, type_str: str, globalns: dict[str, Any]) -> Any | None:  # noqa: C901
         """Safely evaluate a type string using AST validation.
 
         Parses the type string into an AST, validates that it contains only safe
@@ -129,6 +129,18 @@ class Container[T]:
                     ),
                 ):
                     raise TypeError(f"Forbidden AST node in type string: {type(node).__name__}")
+
+                # 🛡️ Sentinel: Mitigate ACE vulnerability by strictly whitelisting allowed ast.Call functions.
+                if isinstance(node, ast.Call):
+                    func_name = None
+                    if isinstance(node.func, ast.Name):
+                        func_name = node.func.id
+                    elif isinstance(node.func, ast.Attribute):
+                        func_name = node.func.attr
+
+                    allowed_funcs = {"Depends", "depends", "Field", "PrivateAttr", "Tag", "Parameter"}
+                    if func_name not in allowed_funcs:
+                        raise TypeError(f"Forbidden function call in type string: {func_name}")
 
                 # Block dunder access to prevent escaping the restricted environment
                 if isinstance(node, ast.Name) and node.id.startswith("__"):


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Unrestricted dynamic type evaluation `eval()` allowed arbitrary `ast.Call` execution. By supplying a maliciously crafted type string to the restricted environment, arbitrary Python functions present in the environment's `__builtins__` or global namespace could be executed.
🎯 Impact: High risk of Arbitrary Code Execution (ACE) allowing malicious logic execution within the host environment.
🔧 Fix: Implemented strict whitelisting within `TypeValidator` to only allow explicit and known `ast.Call` nodes (`Depends`, `depends`, `Field`, `PrivateAttr`, `Tag`, `Parameter`). Also accommodated explicitly prefixed functions (e.g., `cyclopts.Parameter`). Rejected unknown functions with a `TypeError`.
✅ Verification: Tested against standard unit tests and locally verified that arbitrary functions are rejected. Added a corresponding security journal entry tracking the vulnerability.

---
*PR created automatically by Jules for task [3684479189248078740](https://jules.google.com/task/3684479189248078740) started by @bashandbone*

## Summary by Sourcery

Harden dynamic type evaluation in the DI container to prevent arbitrary code execution and document the security fix in the Sentinel journal.

Bug Fixes:
- Block arbitrary function execution during type-string evaluation by strictly whitelisting allowed ast.Call targets in the TypeValidator.

Documentation:
- Add a Sentinel security journal entry describing the ast.Call-based arbitrary code execution vulnerability, its root cause, and the mitigation.