### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary code execution in type string evaluation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,8 @@
 **Vulnerability:** Found an unused `_attempt_import` function in `src/codeweaver/server/mcp/server.py` that dynamically imports a module directly from unvalidated configuration (`import_module(mw.rsplit(".", 1)[0])`), leading to potential arbitrary code execution.
 **Learning:** Functions that perform dynamic imports should not be left around in the codebase if they are unused, especially if they are designed to take unvalidated strings as input.
 **Prevention:** Avoid dynamic imports based on configuration or inputs without strict whitelisting. Use tools like `semgrep` with python security rules to actively catch these patterns.
+
+## 2026-04-21 - Arbitrary code execution vulnerability in type string evaluation
+**Vulnerability:** Found a critical vulnerability in `_safe_eval_type` inside `src/codeweaver/core/di/container.py` where the AST validator did not restrict `ast.Call` nodes. This could allow for arbitrary code execution during `eval()` since any callable in the global namespace could be executed if present in a type string annotation.
+**Learning:** When using `eval()` in restricted environments, it is crucial to meticulously validate all AST nodes to prevent executing unwanted code. Even with restricted built-ins, allowing generic function calls via `ast.Call` defeats the purpose of the security boundary.
+**Prevention:** Always restrict `ast.Call` nodes to a strict whitelist of explicitly required functions (like `Depends`, `Field`, `Parameter`) when validating AST trees for dynamic type evaluation.

--- a/src/codeweaver/core/di/container.py
+++ b/src/codeweaver/core/di/container.py
@@ -84,7 +84,7 @@ class Container[T]:
         self._request_cache: dict[Any, Any] = {}  # Keys can be types or callables
         self._providers_loaded: bool = False  # Track if auto-discovery has run
 
-    def _safe_eval_type(self, type_str: str, globalns: dict[str, Any]) -> Any | None:
+    def _safe_eval_type(self, type_str: str, globalns: dict[str, Any]) -> Any | None:  # noqa: C901
         """Safely evaluate a type string using AST validation.
 
         Parses the type string into an AST, validates that it contains only safe
@@ -135,6 +135,19 @@ class Container[T]:
                     raise TypeError(f"Forbidden dunder name: {node.id}")
                 if isinstance(node, ast.Attribute) and node.attr.startswith("__"):
                     raise TypeError(f"Forbidden dunder attribute: {node.attr}")
+
+                # Security concern: Restrict ast.Call to strictly whitelisted functions to prevent
+                # arbitrary code execution during eval().
+                if isinstance(node, ast.Call):
+                    allowed_funcs = {"Depends", "depends", "Field", "PrivateAttr", "Tag", "Parameter"}
+                    func_name = None
+                    if isinstance(node.func, ast.Name):
+                        func_name = node.func.id
+                    elif isinstance(node.func, ast.Attribute):
+                        func_name = node.func.attr
+
+                    if func_name not in allowed_funcs:
+                        raise TypeError(f"Forbidden function call in type string: {func_name}")
 
                 super().generic_visit(node)
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `_safe_eval_type` inside `src/codeweaver/core/di/container.py` validated AST nodes for safe `eval()` but allowed all `ast.Call` nodes. Since type strings are passed through `eval()` with some built-ins and user-provided namespaces, this could lead to Arbitrary Code Execution (ACE) if an attacker can inject a function call into the evaluated type string annotation.
🎯 Impact: Attackers could execute arbitrary functions available in the global namespace during the dynamic resolution of type annotations.
🔧 Fix: Added strict validation for `ast.Call` nodes, checking against a whitelist of known safe type-hinting related functions (`Depends`, `depends`, `Field`, `PrivateAttr`, `Tag`, `Parameter`).
✅ Verification: `mise //:test` passing, specifically the dependency injection tests (`uv run pytest tests/unit/core/di/`).

---
*PR created automatically by Jules for task [18192920016130478227](https://jules.google.com/task/18192920016130478227) started by @bashandbone*

## Summary by Sourcery

Restrict type string evaluation to a safe subset of function calls to close an arbitrary code execution vulnerability.

Bug Fixes:
- Harden _safe_eval_type AST validation by allowing only a small whitelist of known-safe functions in ast.Call nodes when evaluating type strings.

Documentation:
- Document the new arbitrary code execution vulnerability and its mitigation in the Sentinel security log.