### PR TITLE
⚡ Bolt: Optimize base reranking list comprehension

### DIFF
--- a/src/codeweaver/providers/reranking/providers/base.py
+++ b/src/codeweaver/providers/reranking/providers/base.py
@@ -91,10 +91,12 @@ def default_reranking_output_transformer(
     mapped_scores = sorted(
         ((i, score) for i, score in enumerate(results)), key=lambda x: x[1], reverse=True
     )
+    # ⚡ Bolt: Pre-computed hash map for O(1) rank lookups, reducing algorithm from O(N^2) to O(N)
+    rank_map = {idx: j + 1 for j, (idx, _) in enumerate(mapped_scores)}
     processed_results.extend(
         RerankingResult(
             original_index=i,
-            batch_rank=next((j + 1 for j, (idx, _) in enumerate(mapped_scores) if idx == i), -1),
+            batch_rank=rank_map.get(i, -1),
             score=score,
             chunk=chunk,
         )


### PR DESCRIPTION
💡 What: Optimized the `default_reranking_output_transformer` to use a precomputed hash map for index lookups instead of a nested generator expression with `next()`.
🎯 Why: The original implementation iterated over `mapped_scores` for every chunk, resulting in $O(N^2)$ algorithmic complexity which degraded performance as batch sizes grew.
📊 Impact: Reduces computational complexity from $O(N^2)$ to $O(N)$ by making the inner rank lookup an $O(1)$ dictionary operation.
🔬 Measurement: Run unit tests with larger batch sizes or reranking tests and observe CPU usage and execution time reductions.

---
*PR created automatically by Jules for task [4187152158761050231](https://jules.google.com/task/4187152158761050231) started by @bashandbone*

## Summary by Sourcery

Enhancements:
- Use a precomputed index-to-rank map to achieve O(1) batch rank lookups during reranking result transformation.