### PR TITLE
🛡️ Sentinel: [CRITICAL] Prevent ACE by whitelisting ast.Call in DI Container

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,7 @@
 **Vulnerability:** Found an unused `_attempt_import` function in `src/codeweaver/server/mcp/server.py` that dynamically imports a module directly from unvalidated configuration (`import_module(mw.rsplit(".", 1)[0])`), leading to potential arbitrary code execution.
 **Learning:** Functions that perform dynamic imports should not be left around in the codebase if they are unused, especially if they are designed to take unvalidated strings as input.
 **Prevention:** Avoid dynamic imports based on configuration or inputs without strict whitelisting. Use tools like `semgrep` with python security rules to actively catch these patterns.
+## 2026-04-22 - Unrestricted AST Call nodes in _safe_eval_type
+**Vulnerability:** Found `ast.Call` included in the allowed nodes list of `_safe_eval_type` in `src/codeweaver/core/di/container.py` without validation, which introduces a critical Arbitrary Code Execution (ACE) vulnerability as it permits execution of any callable in the module's global namespace via `eval()`.
+**Learning:** Permitting generic `ast.Call` nodes when parsing untrusted or complex type strings dynamically evaluated via `eval()` can lead to ACE if the type string references available functions in the global scope.
+**Prevention:** Always restrict `ast.Call` nodes to a strict whitelist of explicitly required, known-safe functions (e.g., `Depends`, `Field`) when utilizing AST validation prior to dynamic evaluation.

--- a/src/codeweaver/core/di/container.py
+++ b/src/codeweaver/core/di/container.py
@@ -84,7 +84,7 @@ class Container[T]:
         self._request_cache: dict[Any, Any] = {}  # Keys can be types or callables
         self._providers_loaded: bool = False  # Track if auto-discovery has run
 
-    def _safe_eval_type(self, type_str: str, globalns: dict[str, Any]) -> Any | None:
+    def _safe_eval_type(self, type_str: str, globalns: dict[str, Any]) -> Any | None:  # noqa: C901
         """Safely evaluate a type string using AST validation.
 
         Parses the type string into an AST, validates that it contains only safe
@@ -135,6 +135,20 @@ class Container[T]:
                     raise TypeError(f"Forbidden dunder name: {node.id}")
                 if isinstance(node, ast.Attribute) and node.attr.startswith("__"):
                     raise TypeError(f"Forbidden dunder attribute: {node.attr}")
+
+                # Security Enhancement: Prevent Arbitrary Code Execution (ACE)
+                # Allowing generic ast.Call nodes could permit execution of any callable in the global namespace.
+                # Restrict to known safe functions used in type annotations.
+                if isinstance(node, ast.Call):
+                    func_name = None
+                    if isinstance(node.func, ast.Name):
+                        func_name = node.func.id
+                    elif isinstance(node.func, ast.Attribute):
+                        func_name = node.func.attr
+
+                    allowed_calls = {"Depends", "depends", "Field", "PrivateAttr", "Tag", "Parameter"}
+                    if func_name not in allowed_calls:
+                        raise TypeError(f"Forbidden function call in type string: {func_name}")
 
                 super().generic_visit(node)
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Unrestricted dynamic execution of `ast.Call` nodes during AST validation within the DI Container (`src/codeweaver/core/di/container.py`) introduced a critical Arbitrary Code Execution (ACE) vulnerability. Because generic `ast.Call` validation was previously bypassed prior to standard `eval()`, malicious type hints could theoretically inject callable operations executing directly on the server's global namespace context.
🎯 Impact: Exploitation of this vulnerability could grant an attacker unauthorized code execution privileges, severely compromising server integrity and potentially exposing all sensitive data and API secrets if unverified strings reach the DI resolution framework.
🔧 Fix: We strictly restricted allowable `ast.Call` nodes during the AST verification. Only necessary type hint functions (`Depends`, `depends`, `Field`, `PrivateAttr`, `Tag`, `Parameter`) explicitly declared in a curated whitelist are now accepted for evaluation.
✅ Verification: Ran unit test suite (`uv run pytest tests/unit/core/ --no-cov`), verified code formatting via `mise //:format`, and lint checks via `mise //:check`. Evaluated `read_file` to confirm code correctness and added a `# noqa: C901` for Cyclomatic Complexity requirements. Updated the journal (`.jules/sentinel.md`) to capture the vulnerability.

---
*PR created automatically by Jules for task [7297087579310745208](https://jules.google.com/task/7297087579310745208) started by @bashandbone*

## Summary by Sourcery

Restrict dynamic AST-based type evaluation in the DI container to prevent arbitrary code execution by whitelisting allowed function calls in type hints and documenting the security fix.

Bug Fixes:
- Harden _safe_eval_type AST validation by only allowing specific whitelisted function calls (e.g., Depends, Field, PrivateAttr, Tag, Parameter) in type strings to prevent arbitrary code execution.

Enhancements:
- Document the new AST call restriction and associated ACE vulnerability in the security journal for future reference.

Documentation:
- Update the Sentinel journal with a new entry describing the discovered AST-based arbitrary code execution vulnerability, its cause, and prevention guidance.