### PR TITLE
⚡ Bolt: [avoid generator overhead in VectorSet.by_name]

### DIFF
--- a/src/codeweaver/providers/types/vectors.py
+++ b/src/codeweaver/providers/types/vectors.py
@@ -315,7 +315,11 @@ class VectorSet(BasedModel):
         Returns:
             Matching VectorConfig or None
         """
-        return next((v for v in self.vectors.values() if v.name == name), None)
+        # Bolt Optimization: Avoid generator overhead with next() by using a standard loop
+        for v in self.vectors.values():
+            if v.name == name:
+                return v
+        return None
 
     def by_key(self, key: str) -> VectorConfig | None:
         """Get vector by its logical dict key.


### PR DESCRIPTION
💡 **What:** Replaced the generator expression inside `next()` with a standard `for` loop in `VectorSet.by_name`.
🎯 **Why:** To eliminate the overhead of creating a generator object for a simple key lookup in a dictionary's values.
📊 **Impact:** Provides a micro-optimization by avoiding generator creation overhead in lookups, slightly speeding up searches in hot paths.
🔬 **Measurement:** Review execution time in high-throughput `by_name` lookups or benchmark iterations compared to previous `next()` with generator expression overhead.

---
*PR created automatically by Jules for task [16372396815061258189](https://jules.google.com/task/16372396815061258189) started by @bashandbone*

## Summary by Sourcery

Enhancements:
- Improve VectorSet.by_name performance by avoiding generator creation overhead during vector lookups.