### PR TITLE
⚡ Bolt: [performance improvement] Convert O(N²) rank lookup to O(N) dictionary in reranker

### DIFF
--- a/src/codeweaver/providers/reranking/providers/base.py
+++ b/src/codeweaver/providers/reranking/providers/base.py
@@ -91,10 +91,12 @@ def default_reranking_output_transformer(
     mapped_scores = sorted(
         ((i, score) for i, score in enumerate(results)), key=lambda x: x[1], reverse=True
     )
+    # Pre-compute rank map to change O(n^2) nested lookup to O(n) hash map lookup
+    rank_map = {idx: j + 1 for j, (idx, _) in enumerate(mapped_scores)}
     processed_results.extend(
         RerankingResult(
             original_index=i,
-            batch_rank=next((j + 1 for j, (idx, _) in enumerate(mapped_scores) if idx == i), -1),
+            batch_rank=rank_map.get(i, -1),
             score=score,
             chunk=chunk,
         )


### PR DESCRIPTION
## 💡 What
Replaced a generator comprehension `next(...)` used inside an array extension loop in `default_reranking_output_transformer` with a pre-calculated hash map (`rank_map`).

## 🎯 Why
The nested generator comprehension repeatedly iterated over the elements of `mapped_scores` for *each* index sequentially, causing an O(N²) time complexity algorithmic bottleneck when iterating over document chunks in a reranking process.

## 📊 Impact
Reduces the algorithmic evaluation complexity of document reranking assignments strictly from O(N²) to O(N), offering significantly shorter evaluation periods during heavily populated return arrays by leveraging O(1) constant-time dictionary lookups.

## 🔬 Measurement
The functionality is fully verified by the successful execution of the core `tests/unit/providers/reranking/` test suite and standard testing metrics, preserving exact match outputs functionally.

---
*PR created automatically by Jules for task [4362230007984950645](https://jules.google.com/task/4362230007984950645) started by @bashandbone*

## Summary by Sourcery

Enhancements:
- Replace repeated linear scans over mapped scores with a precomputed dictionary for constant-time batch rank lookup in reranking output transformation.