### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Arbitrary Code Execution in dynamic type evaluation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,7 @@
 **Vulnerability:** Found an unused `_attempt_import` function in `src/codeweaver/server/mcp/server.py` that dynamically imports a module directly from unvalidated configuration (`import_module(mw.rsplit(".", 1)[0])`), leading to potential arbitrary code execution.
 **Learning:** Functions that perform dynamic imports should not be left around in the codebase if they are unused, especially if they are designed to take unvalidated strings as input.
 **Prevention:** Avoid dynamic imports based on configuration or inputs without strict whitelisting. Use tools like `semgrep` with python security rules to actively catch these patterns.
+## 2026-04-22 - Arbitrary Code Execution via unvalidated ast.Call in eval()
+**Vulnerability:** Found a critical Arbitrary Code Execution (ACE) vulnerability in `src/codeweaver/core/di/container.py` where type hints evaluated dynamically via `eval()` allowed generic `ast.Call` nodes. This permitted execution of any callable in the module's global namespace.
+**Learning:** When validating AST trees for dynamic type evaluation using `eval()`, allowing generic `ast.Call` nodes introduces severe ACE risks. Attackers can potentially execute unintended functions present in the environment.
+**Prevention:** Strictly whitelist allowable function names inside `ast.Call` nodes (e.g., `Depends`, `depends`, `Field`, `PrivateAttr`, `Tag`, `Parameter`) before passing the tree to `eval()`.

--- a/src/codeweaver/core/di/container.py
+++ b/src/codeweaver/core/di/container.py
@@ -84,7 +84,7 @@ class Container[T]:
         self._request_cache: dict[Any, Any] = {}  # Keys can be types or callables
         self._providers_loaded: bool = False  # Track if auto-discovery has run
 
-    def _safe_eval_type(self, type_str: str, globalns: dict[str, Any]) -> Any | None:
+    def _safe_eval_type(self, type_str: str, globalns: dict[str, Any]) -> Any | None:  # noqa: C901
         """Safely evaluate a type string using AST validation.
 
         Parses the type string into an AST, validates that it contains only safe
@@ -129,6 +129,18 @@ class Container[T]:
                     ),
                 ):
                     raise TypeError(f"Forbidden AST node in type string: {type(node).__name__}")
+
+                # Restrict ast.Call to explicitly whitelisted security-safe functions to prevent Arbitrary Code Execution during eval.
+                if isinstance(node, ast.Call):
+                    func_name = None
+                    if isinstance(node.func, ast.Name):
+                        func_name = node.func.id
+                    elif isinstance(node.func, ast.Attribute):
+                        func_name = node.func.attr
+
+                    allowed_funcs = frozenset({"Depends", "depends", "Field", "PrivateAttr", "Tag", "Parameter"})
+                    if func_name not in allowed_funcs:
+                        raise TypeError(f"Forbidden function call in type string: {func_name}")
 
                 # Block dunder access to prevent escaping the restricted environment
                 if isinstance(node, ast.Name) and node.id.startswith("__"):


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: The `TypeValidator` class inside `src/codeweaver/core/di/container.py` allowed generic `ast.Call` nodes while evaluating type hint strings using `eval()`.
🎯 **Impact**: This permitted Arbitrary Code Execution (ACE) of any callable available in the module's global namespace, severely compromising the environment.
🔧 **Fix**: Implemented strict whitelisting for `ast.Call` nodes. The validator now explicitly checks `node.func.id` and `node.func.attr` against `{"Depends", "depends", "Field", "PrivateAttr", "Tag", "Parameter"}` before allowing the AST to proceed to `eval()`.
✅ **Verification**: Run `uv run pytest tests/unit/ --no-cov` to ensure no DI or functionality regressions exist, which has been completed.

---
*PR created automatically by Jules for task [10843776226278475619](https://jules.google.com/task/10843776226278475619) started by @bashandbone*

## Summary by Sourcery

Restrict dynamic type evaluation to a safe subset of callable names to close an arbitrary code execution hole and document the security incident in the Sentinel log.

Bug Fixes:
- Harden type hint AST validation by only allowing calls to a small, whitelisted set of functions before evaluating with eval(), preventing arbitrary code execution from type strings.

Documentation:
- Extend the Sentinel security log with details of the newly identified AST-based arbitrary code execution vulnerability and its mitigation.